### PR TITLE
Add periodic cleanup for stale push subscriptions

### DIFF
--- a/packages/server/src/services/pushService.ts
+++ b/packages/server/src/services/pushService.ts
@@ -148,7 +148,7 @@ export function createPushService(
 
   const updateLastSuccessStmt = db.prepare(
     `UPDATE push_subscriptions
-     SET last_success_at = datetime('now'), updated_at = datetime('now')
+     SET last_success_at = datetime('now'), updated_at = datetime('now'), status = 'active'
      WHERE id = ?`,
   );
 

--- a/packages/server/tests/services/pushService.test.ts
+++ b/packages/server/tests/services/pushService.test.ts
@@ -343,6 +343,32 @@ describe("pushService", () => {
       }).not.toThrow();
     });
 
+    it("successful delivery reactivates a subscription expired during send", async () => {
+      pushService.subscribe("child", "https://push.example.com/c1", { p256dh: "p1", auth: "a1" });
+
+      let resolveDelivery!: () => void;
+      const deliveryPromise = new Promise<webpush.SendResult>((resolve) => {
+        resolveDelivery = () => resolve({} as webpush.SendResult);
+      });
+      vi.mocked(webpush.sendNotification).mockReturnValue(deliveryPromise);
+
+      // sendNotification selects the sub while still active
+      pushService.sendNotification("child", { title: "Test", body: "Hello" });
+
+      // Cleanup expires the sub while the push is in flight
+      db.prepare("UPDATE push_subscriptions SET status = 'expired' WHERE endpoint = ?")
+        .run("https://push.example.com/c1");
+
+      // Push succeeds — success handler should reactivate the sub
+      resolveDelivery();
+
+      await vi.waitFor(() => {
+        const row = db.prepare("SELECT status FROM push_subscriptions WHERE endpoint = ?")
+          .get("https://push.example.com/c1") as Record<string, unknown>;
+        expect(row.status).toBe("active");
+      });
+    });
+
     it("sends JSON payload with title, body, and data", () => {
       pushService.subscribe("admin", "https://push.example.com/a1", { p256dh: "p1", auth: "a1" });
 


### PR DESCRIPTION
## Summary

Closes #21. The `push_subscriptions` table accumulates `failed` rows permanently and never uses the `expired` status. This adds a background cleanup job that runs on server startup and every 24 hours.

- **Deletes** subscriptions with `status = 'failed'` where `updated_at` is older than 30 days
- **Marks** active subscriptions as `expired` when `COALESCE(last_success_at, created_at)` exceeds 90 days
- Cleanup is a side-effect operation wrapped in try-catch so it never crashes the server
- Auto-starts inside `createPushService()` with `setInterval` + `.unref()` (follows existing rate limiter pattern)

## Changes

| File | What |
|------|------|
| `pushService.ts` | +47 lines: cleanup constants, cached prepared statements, `cleanupStaleSubscriptions()`, try-catch wrappers, auto-start interval |
| `pushService.test.ts` | +191 lines: 11 test cases covering delete/expire logic, boundary conditions at 29/31 and 89/91 days, null fallback, combined operations |

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] All 576 server unit tests pass (11 new cleanup tests)
- [x] E2E tests: 16 pass, 7 fail (pre-existing rate limiter flakiness, unrelated)
- [x] Boundary tests verify thresholds at day 29/31 (failed TTL) and day 89/91 (inactive TTL)
- [x] Try-catch verified: startup failure logs error but doesn't block server boot