### PR TITLE
Add offline UX and activity retention job

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary.js";
 import BottomNav from "./components/BottomNav.js";
 import AdminGuard from "./components/AdminGuard.js";
 import AdminLayout from "./layouts/AdminLayout.js";
+import OfflineBanner from "./components/OfflineBanner.js";
 import Today from "./pages/Today.js";
 import Routines from "./pages/Routines.js";
 import Rewards from "./pages/Rewards.js";
@@ -87,6 +88,7 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
+        <OfflineBanner />
         <Routes>
           <Route path="/" element={<Navigate to="/today" replace />} />
 

--- a/packages/client/src/components/OfflineBanner.tsx
+++ b/packages/client/src/components/OfflineBanner.tsx
@@ -1,0 +1,17 @@
+import { useOnline } from "../contexts/OnlineContext.js";
+
+export default function OfflineBanner() {
+  const isOnline = useOnline();
+
+  if (isOnline) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="bg-[var(--color-amber-100)] px-4 py-2 text-center text-sm font-medium text-[var(--color-amber-700)]"
+    >
+      You&apos;re offline. Changes can&apos;t be saved right now.
+    </div>
+  );
+}

--- a/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
+++ b/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
@@ -188,6 +188,7 @@ function ApprovalCard({
           type="button"
           onClick={handleReject}
           disabled={!isOnline || isActionPending}
+          title={!isOnline ? "You're offline" : undefined}
           className="min-h-touch rounded-xl px-5 py-2 font-display font-bold text-[var(--color-text-muted)] bg-[var(--color-surface-muted)] transition-colors hover:bg-[var(--color-red-600)] hover:text-white disabled:opacity-50"
         >
           {isThisRejectPending ? "Rejecting..." : "Reject"}
@@ -196,6 +197,7 @@ function ApprovalCard({
           type="button"
           onClick={handleApprove}
           disabled={!isOnline || isActionPending}
+          title={!isOnline ? "You're offline" : undefined}
           className="min-h-touch rounded-xl bg-[var(--color-emerald-500)] px-5 py-2 font-display font-bold text-white transition-colors hover:bg-[var(--color-emerald-600)] disabled:opacity-50"
         >
           {isThisApprovePending ? "Approving..." : "Approve"}

--- a/packages/client/src/features/admin/pin/PinEntry.tsx
+++ b/packages/client/src/features/admin/pin/PinEntry.tsx
@@ -1,11 +1,13 @@
 import { useState, useRef, useEffect, type FormEvent } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { api } from "../../../api/client.js";
+import { useOnline } from "../../../contexts/OnlineContext.js";
 
 export default function PinEntry() {
   const [pin, setPin] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const isOnline = useOnline();
   const navigate = useNavigate();
   const pinRef = useRef<HTMLInputElement>(null);
 
@@ -51,6 +53,12 @@ export default function PinEntry() {
         <h1 className="mt-5 font-display text-2xl font-bold text-[var(--color-text)]">Admin Access</h1>
         <p className="mt-1 text-sm text-[var(--color-text-muted)]">Enter your PIN to manage chores</p>
 
+        {!isOnline && (
+          <p className="mt-4 text-sm font-medium text-[var(--color-amber-700)]" role="status">
+            PIN verification requires a connection.
+          </p>
+        )}
+
         <form onSubmit={handleSubmit} className="mt-6 space-y-4">
           <div>
             <label htmlFor="pin" className="sr-only">
@@ -80,7 +88,7 @@ export default function PinEntry() {
           )}
           <button
             type="submit"
-            disabled={loading || pin.length < 6}
+            disabled={loading || pin.length < 6 || !isOnline}
             className="w-full rounded-xl font-display text-base font-semibold text-white shadow-glow-amber transition-all duration-200 hover:-translate-y-px disabled:cursor-not-allowed disabled:opacity-50"
             style={{ background: "linear-gradient(135deg, var(--color-amber-500), var(--color-amber-600))", padding: "14px" }}
           >

--- a/packages/client/src/features/child/chores/QuickChoreLog.tsx
+++ b/packages/client/src/features/child/chores/QuickChoreLog.tsx
@@ -152,6 +152,7 @@ export default function QuickChoreLog() {
                 type="button"
                 onClick={() => handleChoreSelect(chore)}
                 disabled={!isOnline}
+                title={!isOnline ? "You're offline" : undefined}
                 className="flex w-full items-center justify-between rounded-xl bg-[var(--color-surface-muted)] px-4 py-3 text-left font-medium text-[var(--color-text-secondary)] transition-all duration-200 hover:bg-[var(--color-amber-50)] hover:text-[var(--color-amber-700)] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <span>{chore.name}</span>
@@ -179,6 +180,7 @@ export default function QuickChoreLog() {
               type="button"
               onClick={() => handleTierSelect(tier)}
               disabled={!isOnline || submitMutation.isPending}
+              title={!isOnline ? "You're offline" : undefined}
               className="flex w-full items-center justify-between rounded-xl bg-[var(--color-surface-muted)] px-4 py-3 text-left transition-all duration-200 hover:bg-[var(--color-emerald-50)] hover:ring-1 hover:ring-[var(--color-emerald-400)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span className="font-medium text-[var(--color-text-secondary)]">{tier.name}</span>

--- a/packages/client/src/features/child/rewards/RewardCard.tsx
+++ b/packages/client/src/features/child/rewards/RewardCard.tsx
@@ -71,6 +71,7 @@ export default function RewardCard({ reward, availablePoints, pendingRequest }: 
           type="button"
           onClick={handleCancel}
           disabled={cancelMutation.isPending || !isOnline}
+          title={!isOnline ? "You're offline" : undefined}
           className="mt-3 text-sm font-medium text-[var(--color-red-600)] disabled:opacity-50"
         >
           {cancelMutation.isPending ? "Canceling..." : "Cancel Request"}
@@ -133,6 +134,7 @@ export default function RewardCard({ reward, availablePoints, pendingRequest }: 
           type="button"
           onClick={() => setIsConfirming(true)}
           disabled={!isAffordable || !isOnline || submitMutation.isPending}
+          title={!isOnline ? "You're offline" : undefined}
           className="mt-3 w-full rounded-xl bg-[var(--color-amber-500)] py-2.5 font-bold text-white transition-all duration-200 hover:bg-[var(--color-amber-600)] disabled:cursor-not-allowed disabled:bg-[var(--color-border)] disabled:text-[var(--color-text-faint)]"
         >
           {isAffordable ? "Request" : `Need ${reward.pointsCost - availablePoints} more pts`}

--- a/packages/client/src/features/child/routines/RoutineChecklist.tsx
+++ b/packages/client/src/features/child/routines/RoutineChecklist.tsx
@@ -229,6 +229,7 @@ export default function RoutineChecklist() {
           type="button"
           onClick={handleSubmit}
           disabled={!isAllChecked || !isOnline || submitRoutine.isPending}
+          title={!isOnline ? "You're offline" : undefined}
           className="w-full rounded-full bg-[var(--color-emerald-500)] px-6 py-4 text-lg font-bold text-white shadow-card transition-all duration-200 enabled:hover:bg-[var(--color-emerald-600)] enabled:active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {submitRoutine.isPending ? "Submitting..." : "Complete Routine!"}

--- a/packages/client/tests/components/OfflineBanner.test.tsx
+++ b/packages/client/tests/components/OfflineBanner.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { OnlineProvider } from "../../src/contexts/OnlineContext.js";
+import OfflineBanner from "../../src/components/OfflineBanner.js";
+
+function renderBanner() {
+  return render(
+    <OnlineProvider>
+      <OfflineBanner />
+    </OnlineProvider>,
+  );
+}
+
+function goOffline() {
+  act(() => {
+    Object.defineProperty(navigator, "onLine", { value: false, writable: true });
+    window.dispatchEvent(new Event("offline"));
+  });
+}
+
+function goOnline() {
+  act(() => {
+    Object.defineProperty(navigator, "onLine", { value: true, writable: true });
+    window.dispatchEvent(new Event("online"));
+  });
+}
+
+describe("OfflineBanner", () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, "onLine", { value: true, writable: true });
+  });
+
+  it("is not visible when online", () => {
+    renderBanner();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("shows banner when offline", () => {
+    renderBanner();
+    goOffline();
+
+    const banner = screen.getByRole("status");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent("You're offline");
+  });
+
+  it("hides banner when coming back online", () => {
+    renderBanner();
+    goOffline();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    goOnline();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("has aria-live polite for screen reader announcement", () => {
+    renderBanner();
+    goOffline();
+
+    expect(screen.getByRole("status")).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,6 +3,7 @@ import { openDatabase } from "./db/connection.js";
 import { runMigrations } from "./db/migrate.js";
 import { createSettingsService } from "./services/settingsService.js";
 import { createApp } from "./app.js";
+import { startRetentionJob, type RetentionJobHandle } from "./jobs/retentionJob.js";
 
 const SHUTDOWN_TIMEOUT_MS = 5_000;
 
@@ -10,6 +11,7 @@ async function main() {
   console.log("Starting Chore App server...");
 
   let db: ReturnType<typeof openDatabase> | null = null;
+  let retentionJob: RetentionJobHandle | null = null;
 
   try {
     const config = loadConfig();
@@ -27,6 +29,8 @@ async function main() {
     const app = createApp(db, config);
     console.log("VAPID keys initialized.");
 
+    retentionJob = startRetentionJob(db);
+
     const server = app.listen(config.port, () => {
       console.log(`Server listening on port ${config.port}`);
       console.log(`Public origin: ${config.publicOrigin}`);
@@ -42,6 +46,7 @@ async function main() {
       forceExit.unref();
 
       server.close(() => {
+        retentionJob?.stop();
         db?.close();
         console.log("Server stopped.");
         process.exit(0);

--- a/packages/server/src/jobs/retentionJob.ts
+++ b/packages/server/src/jobs/retentionJob.ts
@@ -1,0 +1,56 @@
+import type Database from "better-sqlite3";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface RetentionJobHandle {
+  stop(): void;
+}
+
+export function createRetentionPurger(db: Database.Database) {
+  const selectRetentionStmt = db.prepare(
+    "SELECT value FROM settings WHERE key = ?",
+  );
+  const deleteExpiredStmt = db.prepare(
+    "DELETE FROM activity_events WHERE created_at < datetime('now', ?)",
+  );
+
+  return function purgeExpiredActivityEvents(): number {
+    const retentionRow = selectRetentionStmt.get("activity_retention_days") as
+      | { value: string }
+      | undefined;
+
+    const retentionDays = retentionRow ? Number(retentionRow.value) : 365;
+
+    const result = deleteExpiredStmt.run(`-${retentionDays} days`);
+    return result.changes;
+  };
+}
+
+export function purgeExpiredActivityEvents(db: Database.Database): number {
+  return createRetentionPurger(db)();
+}
+
+export function startRetentionJob(db: Database.Database): RetentionJobHandle {
+  const purge = createRetentionPurger(db);
+
+  function runPurge() {
+    try {
+      const deleted = purge();
+      if (deleted > 0) {
+        console.log(`Retention job: purged ${deleted} expired activity events.`);
+      }
+    } catch (err) {
+      console.error("Retention job failed:", err);
+    }
+  }
+
+  runPurge();
+  const intervalId = setInterval(runPurge, ONE_DAY_MS);
+  intervalId.unref();
+
+  return {
+    stop() {
+      clearInterval(intervalId);
+    },
+  };
+}

--- a/packages/server/tests/jobs/retentionJob.test.ts
+++ b/packages/server/tests/jobs/retentionJob.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type Database from "better-sqlite3";
+import { createTestDb } from "../db-helpers.js";
+import { purgeExpiredActivityEvents } from "../../src/jobs/retentionJob.js";
+
+let db: Database.Database;
+
+beforeEach(() => {
+  db = createTestDb();
+  db.prepare("INSERT INTO settings (key, value) VALUES (?, ?)").run(
+    "activity_retention_days",
+    "30",
+  );
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function insertActivityEvent(createdAt: string): void {
+  db.prepare(
+    "INSERT INTO activity_events (event_type, created_at) VALUES (?, ?)",
+  ).run("test_event", createdAt);
+}
+
+function insertPointsLedgerEntry(createdAt: string): void {
+  db.prepare(
+    "INSERT INTO points_ledger (entry_type, reference_table, reference_id, amount, created_at) VALUES (?, ?, ?, ?, ?)",
+  ).run("chore", "chore_logs", 1, 10, createdAt);
+}
+
+function countRows(table: string): number {
+  const row = db.prepare(`SELECT COUNT(*) as n FROM ${table}`).get() as {
+    n: number;
+  };
+  return row.n;
+}
+
+describe("purgeExpiredActivityEvents", () => {
+  it("deletes activity events older than the retention period", () => {
+    insertActivityEvent("2020-01-01 00:00:00");
+    insertActivityEvent("2020-06-01 00:00:00");
+
+    const deleted = purgeExpiredActivityEvents(db);
+
+    expect(deleted).toBe(2);
+    expect(countRows("activity_events")).toBe(0);
+  });
+
+  it("preserves events within the retention period", () => {
+    const recent = new Date().toISOString().replace("T", " ").slice(0, 19);
+    insertActivityEvent(recent);
+    insertActivityEvent("2020-01-01 00:00:00");
+
+    const deleted = purgeExpiredActivityEvents(db);
+
+    expect(deleted).toBe(1);
+    expect(countRows("activity_events")).toBe(1);
+  });
+
+  it("does not delete points_ledger entries regardless of age", () => {
+    insertPointsLedgerEntry("2020-01-01 00:00:00");
+    insertActivityEvent("2020-01-01 00:00:00");
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("points_ledger")).toBe(1);
+    expect(countRows("activity_events")).toBe(0);
+  });
+
+  it("does not delete routine_completions", () => {
+    db.prepare(
+      `INSERT INTO routines (name, time_slot, completion_rule, points, requires_approval, active) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("Test Routine", "morning", "once_per_day", 10, 0, 1);
+    db.prepare(
+      `INSERT INTO routine_completions (routine_id, routine_name_snapshot, time_slot_snapshot, completion_rule_snapshot, points_snapshot, requires_approval_snapshot, status, local_date, idempotency_key, completed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(1, "Test Routine", "morning", "once_per_day", 10, 0, "approved", "2020-01-01", "key-1", "2020-01-01 00:00:00");
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("routine_completions")).toBe(1);
+  });
+
+  it("does not delete chore_logs", () => {
+    db.prepare(
+      `INSERT INTO chores (name, active) VALUES (?, ?)`,
+    ).run("Test Chore", 1);
+    db.prepare(
+      `INSERT INTO chore_tiers (chore_id, name, points, sort_order) VALUES (?, ?, ?, ?)`,
+    ).run(1, "Basic", 5, 0);
+    db.prepare(
+      `INSERT INTO chore_logs (chore_id, tier_id, chore_name_snapshot, tier_name_snapshot, points_snapshot, requires_approval_snapshot, status, local_date, idempotency_key, logged_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(1, 1, "Test Chore", "Basic", 5, 0, "approved", "2020-01-01", "key-2", "2020-01-01 00:00:00");
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("chore_logs")).toBe(1);
+  });
+
+  it("does not delete reward_requests", () => {
+    db.prepare(
+      `INSERT INTO rewards (name, points_cost, active) VALUES (?, ?, ?)`,
+    ).run("Test Reward", 50, 1);
+    db.prepare(
+      `INSERT INTO reward_requests (reward_id, reward_name_snapshot, cost_snapshot, status, local_date, idempotency_key, requested_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run(1, "Test Reward", 50, "pending", "2020-01-01", "key-3", "2020-01-01 00:00:00");
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("reward_requests")).toBe(1);
+  });
+
+  it("does not delete badges_earned", () => {
+    db.prepare(
+      `INSERT INTO badges_earned (badge_key, earned_at) VALUES (?, ?)`,
+    ).run("first_routine", "2020-01-01 00:00:00");
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("badges_earned")).toBe(1);
+  });
+
+  it("handles empty activity_events table without error", () => {
+    const deleted = purgeExpiredActivityEvents(db);
+
+    expect(deleted).toBe(0);
+    expect(countRows("activity_events")).toBe(0);
+  });
+
+  it("respects changed retention_days setting", () => {
+    insertActivityEvent("2020-01-01 00:00:00");
+    const recent = new Date().toISOString().replace("T", " ").slice(0, 19);
+    insertActivityEvent(recent);
+
+    db.prepare("UPDATE settings SET value = ? WHERE key = ?").run(
+      "1",
+      "activity_retention_days",
+    );
+
+    purgeExpiredActivityEvents(db);
+
+    expect(countRows("activity_events")).toBe(1);
+  });
+
+  it("defaults to 365 days when setting is missing", () => {
+    db.prepare("DELETE FROM settings WHERE key = ?").run(
+      "activity_retention_days",
+    );
+
+    const twoYearsAgo = new Date(
+      Date.now() - 2 * 365 * 24 * 60 * 60 * 1000,
+    );
+    const twoYearsAgoStr = twoYearsAgo
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    insertActivityEvent(twoYearsAgoStr);
+
+    const sixMonthsAgo = new Date(
+      Date.now() - 180 * 24 * 60 * 60 * 1000,
+    );
+    const sixMonthsAgoStr = sixMonthsAgo
+      .toISOString()
+      .replace("T", " ")
+      .slice(0, 19);
+    insertActivityEvent(sixMonthsAgoStr);
+
+    const deleted = purgeExpiredActivityEvents(db);
+
+    expect(deleted).toBe(1);
+    expect(countRows("activity_events")).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds an offline banner (`OfflineBanner.tsx`) that appears when the device loses connectivity, with `aria-live="polite"` for screen reader announcement
- Disables all mutation buttons (submit, approve, reject, request, cancel) when offline across 6 components, with tooltip feedback explaining the offline state
- Gates admin PIN entry with an offline-specific message since verification requires the server
- Adds a configurable activity retention job (`retentionJob.ts`) that purges expired `activity_events` on a daily interval while never touching canonical tables (`points_ledger`, `routine_completions`, `chore_logs`, `reward_requests`, `badges_earned`)

## Scope

Milestone 5, Tasks 5.3 (Offline Mode UX) + 5.4 (Activity Retention Job) + related tests from 5.8.

**New files:**
- `packages/client/src/components/OfflineBanner.tsx`
- `packages/server/src/jobs/retentionJob.ts`
- `packages/client/tests/components/OfflineBanner.test.tsx`
- `packages/server/tests/jobs/retentionJob.test.ts`

**Modified:** `App.tsx`, `ApprovalsScreen.tsx`, `PinEntry.tsx`, `QuickChoreLog.tsx`, `RewardCard.tsx`, `RoutineChecklist.tsx`, `index.ts`

11 files changed, +334 / -1

## Test plan

- [ ] Offline banner appears when network is disabled, hides when reconnected
- [ ] All submit/approve/reject/request buttons disabled while offline with tooltip
- [ ] Admin PIN entry shows offline message
- [ ] Retention job deletes activity events older than configured retention days
- [ ] Retention job never touches points_ledger, routine_completions, chore_logs, reward_requests, or badges_earned
- [ ] Retention job handles empty table without error
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test -- --run` passes (848 tests, 65 files)