### PR TITLE
Add animations and transitions for polish

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route, Navigate, Outlet } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useSyncOnReconnect } from "./lib/draft-sync.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
@@ -53,6 +53,18 @@ function ChildErrorFallback() {
   );
 }
 
+function TabContent() {
+  const location = useLocation();
+  // Re-key on the top-level path segment so the fade-in replays on tab switch
+  const tabKey = location.pathname.split("/")[1] || "today";
+
+  return (
+    <div key={tabKey} className="animate-tab-enter">
+      <Outlet />
+    </div>
+  );
+}
+
 function AppShell() {
   return (
     <div className="pb-16">
@@ -64,7 +76,7 @@ function AppShell() {
       </a>
       <main id="main-content">
         <ErrorBoundary fallback={<ChildErrorFallback />}>
-          <Outlet />
+          <TabContent />
         </ErrorBoundary>
       </main>
       <BottomNav />

--- a/packages/client/src/components/badges/BadgeCollection.tsx
+++ b/packages/client/src/components/badges/BadgeCollection.tsx
@@ -4,9 +4,10 @@ import BadgeIcon from "./BadgeIcon.js";
 
 interface BadgeCollectionProps {
   earnedBadges: Badge[];
+  newlyEarnedKeys?: Set<string>;
 }
 
-export default function BadgeCollection({ earnedBadges }: BadgeCollectionProps) {
+export default function BadgeCollection({ earnedBadges, newlyEarnedKeys }: BadgeCollectionProps) {
   const earnedKeySet = new Set(earnedBadges.map((badge) => badge.badgeKey));
 
   return (
@@ -16,7 +17,12 @@ export default function BadgeCollection({ earnedBadges }: BadgeCollectionProps) 
       aria-label={`Badges: ${earnedBadges.length} of ${Object.keys(BADGE_KEYS).length} earned`}
     >
       {Object.values(BADGE_KEYS).map((key) => (
-        <BadgeIcon key={key} badgeKey={key} isEarned={earnedKeySet.has(key)} />
+        <BadgeIcon
+          key={key}
+          badgeKey={key}
+          isEarned={earnedKeySet.has(key)}
+          isNewlyEarned={newlyEarnedKeys?.has(key)}
+        />
       ))}
     </div>
   );

--- a/packages/client/src/components/badges/BadgeIcon.tsx
+++ b/packages/client/src/components/badges/BadgeIcon.tsx
@@ -1,6 +1,7 @@
 interface BadgeIconProps {
   badgeKey: string;
   isEarned: boolean;
+  isNewlyEarned?: boolean;
 }
 
 const BADGE_DISPLAY: Record<string, { label: string; emoji: string }> = {
@@ -14,7 +15,7 @@ const BADGE_DISPLAY: Record<string, { label: string; emoji: string }> = {
   solo_act: { label: "Solo Act", emoji: "\uD83C\uDFAF" },
 };
 
-export default function BadgeIcon({ badgeKey, isEarned }: BadgeIconProps) {
+export default function BadgeIcon({ badgeKey, isEarned, isNewlyEarned }: BadgeIconProps) {
   const display = BADGE_DISPLAY[badgeKey] ?? { label: badgeKey, emoji: "\uD83C\uDFC5" };
 
   return (
@@ -28,7 +29,7 @@ export default function BadgeIcon({ badgeKey, isEarned }: BadgeIconProps) {
           isEarned
             ? "bg-gradient-to-br from-violet-100 to-violet-50 shadow-glow-violet dark:from-violet-900/50 dark:to-violet-800/30"
             : "bg-[var(--color-surface-muted)]"
-        }`}
+        } ${isNewlyEarned ? "animate-badge-unlock animate-badge-glow" : ""}`}
       >
         <span
           className={isEarned ? "" : "opacity-40 grayscale"}

--- a/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
+++ b/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
@@ -125,6 +125,7 @@ function ApprovalCard({
   isOnline,
 }: ApprovalCardProps) {
   const [note, setNote] = useState("");
+  const [isSlidingOut, setIsSlidingOut] = useState(false);
 
   const isThisApprovePending =
     approveMutation.isPending &&
@@ -139,23 +140,21 @@ function ApprovalCard({
   const isActionPending = isThisApprovePending || isThisRejectPending;
 
   function handleApprove() {
-    approveMutation.mutate({
-      type,
-      id,
-      reviewNote: note.trim() || undefined,
-    });
+    approveMutation.mutate(
+      { type, id, reviewNote: note.trim() || undefined },
+      { onSuccess: () => setIsSlidingOut(true) },
+    );
   }
 
   function handleReject() {
-    rejectMutation.mutate({
-      type,
-      id,
-      reviewNote: note.trim() || undefined,
-    });
+    rejectMutation.mutate(
+      { type, id, reviewNote: note.trim() || undefined },
+      { onSuccess: () => setIsSlidingOut(true) },
+    );
   }
 
   return (
-    <div className="rounded-2xl bg-[var(--color-surface)] p-4 shadow-card">
+    <div className={`rounded-2xl bg-[var(--color-surface)] p-4 shadow-card ${isSlidingOut ? "animate-slide-out" : ""}`}>
       <div className="flex items-start justify-between gap-3">
         <h3 className="font-display text-base font-bold text-[var(--color-text)]">
           {name}

--- a/packages/client/src/features/child/me/MeScreen.tsx
+++ b/packages/client/src/features/child/me/MeScreen.tsx
@@ -1,3 +1,4 @@
+import { useRef, useMemo, useEffect } from "react";
 import { usePoints } from "../rewards/hooks/usePoints.js";
 import { useBadges } from "./hooks/useBadges.js";
 import { useRecentActivity } from "./hooks/useRecentActivity.js";
@@ -10,6 +11,27 @@ export default function MeScreen() {
   const { data: points, isLoading: isLoadingPoints, error: pointsError, refetch: refetchPoints } = usePoints();
   const { data: badges, isLoading: isLoadingBadges, error: badgesError, refetch: refetchBadges } = useBadges();
   const { data: activity, isLoading: isLoadingActivity, error: activityError, refetch: refetchActivity } = useRecentActivity();
+
+  const previousBadgeKeysRef = useRef<Set<string>>(new Set());
+  const newlyEarnedKeys = useMemo(() => {
+    if (!badges) return new Set<string>();
+    const currentKeys = new Set(badges.map((b) => b.badgeKey));
+    const newKeys = new Set<string>();
+    for (const key of currentKeys) {
+      if (!previousBadgeKeysRef.current.has(key)) {
+        newKeys.add(key);
+      }
+    }
+    const isInitialLoad = previousBadgeKeysRef.current.size === 0;
+    return isInitialLoad ? new Set<string>() : newKeys;
+  }, [badges]);
+
+  // Ref update must live in useEffect — mutating refs inside useMemo breaks Strict Mode double-render
+  useEffect(() => {
+    if (badges) {
+      previousBadgeKeysRef.current = new Set(badges.map((b) => b.badgeKey));
+    }
+  }, [badges]);
 
   const isLoading = isLoadingPoints || isLoadingBadges || isLoadingActivity;
   const error = pointsError || badgesError || activityError;
@@ -60,7 +82,7 @@ export default function MeScreen() {
       <div className="mt-8">
         <h2 className="font-display text-lg font-semibold text-[var(--color-text-secondary)]">Badges</h2>
         <div className="mt-3 rounded-3xl bg-[var(--color-surface)] p-4 shadow-card">
-          <BadgeCollection earnedBadges={earnedBadges} />
+          <BadgeCollection earnedBadges={earnedBadges} newlyEarnedKeys={newlyEarnedKeys} />
         </div>
       </div>
 

--- a/packages/client/src/features/child/rewards/PointsDisplay.tsx
+++ b/packages/client/src/features/child/rewards/PointsDisplay.tsx
@@ -1,10 +1,14 @@
 import type { PointsBalance } from "@chore-app/shared";
+import { useAnimatedNumber } from "../../../hooks/useAnimatedNumber.js";
 
 interface PointsDisplayProps {
   balance: PointsBalance;
 }
 
 export default function PointsDisplay({ balance }: PointsDisplayProps) {
+  const displayedAvailable = useAnimatedNumber(balance.available);
+  const displayedTotal = useAnimatedNumber(balance.total);
+
   return (
     <div
       className="relative overflow-hidden rounded-3xl p-6 text-white shadow-glow-amber"
@@ -24,11 +28,11 @@ export default function PointsDisplay({ balance }: PointsDisplayProps) {
       <div className="relative text-center">
         <p className="text-sm font-medium text-white/90">Available Points</p>
         <p className="font-display text-5xl font-bold" data-testid="available-points">
-          {balance.available}
+          {displayedAvailable}
         </p>
       </div>
       <div className="relative mt-2 flex justify-center gap-6 text-sm text-white/90">
-        <span>Total: {balance.total}</span>
+        <span>Total: {displayedTotal}</span>
         {balance.reserved > 0 && <span>Reserved: {balance.reserved}</span>}
       </div>
     </div>

--- a/packages/client/src/features/child/rewards/RewardCard.tsx
+++ b/packages/client/src/features/child/rewards/RewardCard.tsx
@@ -52,7 +52,7 @@ export default function RewardCard({ reward, availablePoints, pendingRequest }: 
 
   if (pendingRequest) {
     return (
-      <div className="rounded-3xl bg-[var(--color-surface)] p-4 shadow-card ring-1 ring-[var(--color-border)]">
+      <div className="animate-card-press rounded-3xl bg-[var(--color-surface)] p-4 shadow-card ring-1 ring-[var(--color-border)]">
         {reward.imageUrl && (
           <img
             src={reward.imageUrl}
@@ -80,7 +80,7 @@ export default function RewardCard({ reward, availablePoints, pendingRequest }: 
   }
 
   return (
-    <div className="rounded-3xl bg-[var(--color-surface)] p-4 shadow-card ring-1 ring-[var(--color-border)]">
+    <div className="animate-card-press rounded-3xl bg-[var(--color-surface)] p-4 shadow-card ring-1 ring-[var(--color-border)]">
       {reward.imageUrl && (
         <img
           src={reward.imageUrl}

--- a/packages/client/src/features/child/routines/ChecklistItem.tsx
+++ b/packages/client/src/features/child/routines/ChecklistItem.tsx
@@ -31,13 +31,13 @@ export default function ChecklistItem({ item, isChecked, onToggle }: Props) {
       <div
         className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border-2 transition-all duration-200 ${
           isChecked
-            ? "border-[var(--color-emerald-500)] bg-[var(--color-emerald-500)]"
+            ? "border-[var(--color-emerald-500)] bg-[var(--color-emerald-500)] animate-checkbox-pop"
             : "border-[var(--color-border)] bg-[var(--color-surface)]"
         }`}
       >
         {isChecked && (
           <svg
-            className="h-5 w-5 text-white"
+            className="h-5 w-5 text-white animate-checkmark-draw"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"

--- a/packages/client/src/features/child/routines/RoutineChecklist.tsx
+++ b/packages/client/src/features/child/routines/RoutineChecklist.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from "react";
+import { useCallback, useRef, useEffect, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useRoutine } from "./hooks/useRoutine.js";
 import { useSubmitRoutine } from "./hooks/useSubmitRoutine.js";
@@ -18,6 +18,7 @@ export default function RoutineChecklist() {
 
   const { data: routine, isLoading: isRoutineLoading, error: routineError } = useRoutine(routineId);
   const submitRoutine = useSubmitRoutine();
+  const [isShowingCelebration, setIsShowingCelebration] = useState(false);
 
   const {
     draftItems,
@@ -65,7 +66,8 @@ export default function RoutineChecklist() {
       {
         onSuccess: async () => {
           try { await deleteDraft(routine.id); } catch { /* IndexedDB unavailable */ }
-          navigate("/routines");
+          setIsShowingCelebration(true);
+          navigationTimeoutRef.current = setTimeout(() => navigate("/routines"), 800);
         },
         onError: async (error: unknown) => {
           const apiError = error && typeof error === "object" && "code" in error
@@ -225,15 +227,36 @@ export default function RoutineChecklist() {
             You're offline -- connect to submit.
           </p>
         )}
-        <button
-          type="button"
-          onClick={handleSubmit}
-          disabled={!isAllChecked || !isOnline || submitRoutine.isPending}
-          className="w-full rounded-full bg-[var(--color-emerald-500)] px-6 py-4 text-lg font-bold text-white shadow-card transition-all duration-200 enabled:hover:bg-[var(--color-emerald-600)] enabled:active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          {submitRoutine.isPending ? "Submitting..." : "Complete Routine!"}
-        </button>
+        <div className="celebration-container">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!isAllChecked || !isOnline || submitRoutine.isPending}
+            className="w-full rounded-full bg-[var(--color-emerald-500)] px-6 py-4 text-lg font-bold text-white shadow-card transition-all duration-200 enabled:hover:bg-[var(--color-emerald-600)] enabled:active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {submitRoutine.isPending ? "Submitting..." : "Complete Routine!"}
+          </button>
+          {isShowingCelebration && (
+            <>
+              <span className="sparkle" aria-hidden="true" />
+              <span className="sparkle" aria-hidden="true" />
+              <span className="sparkle" aria-hidden="true" />
+              <span className="sparkle" aria-hidden="true" />
+            </>
+          )}
+        </div>
       </div>
+
+      {isShowingCelebration && (
+        <div
+          className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center"
+          aria-live="polite"
+        >
+          <p className="animate-tab-enter font-display text-4xl font-bold text-[var(--color-emerald-500)]" data-emoji>
+            &#127881;
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/hooks/useAnimatedNumber.ts
+++ b/packages/client/src/hooks/useAnimatedNumber.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect, useRef } from "react";
+
+const ANIMATION_DURATION_MS = 300;
+
+/**
+ * Animates a number from its previous value to the current target.
+ * Respects prefers-reduced-motion by skipping to the target immediately.
+ */
+export function useAnimatedNumber(target: number): number {
+  const [displayed, setDisplayed] = useState(target);
+  const previousRef = useRef(target);
+  const frameRef = useRef<number>();
+
+  useEffect(() => {
+    const from = previousRef.current;
+    previousRef.current = target;
+
+    if (from === target) return;
+
+    // Skip animation when user prefers reduced motion
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (prefersReducedMotion) {
+      setDisplayed(target);
+      return;
+    }
+
+    const startTime = performance.now();
+    const delta = target - from;
+
+    function tick() {
+      const elapsed = performance.now() - startTime;
+      const progress = Math.min(elapsed / ANIMATION_DURATION_MS, 1);
+      // Ease-out curve
+      const eased = 1 - (1 - progress) ** 3;
+      setDisplayed(Math.round(from + delta * eased));
+
+      if (progress < 1) {
+        frameRef.current = requestAnimationFrame(tick);
+      }
+    }
+
+    frameRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (frameRef.current) cancelAnimationFrame(frameRef.current);
+    };
+  }, [target]);
+
+  return displayed;
+}

--- a/packages/client/src/styles/animations.css
+++ b/packages/client/src/styles/animations.css
@@ -1,0 +1,224 @@
+/* =============================================
+   Animation keyframes & utility classes
+   =============================================
+   GPU-composited (transform/opacity only) wherever possible.
+   Every animation is disabled when the user prefers reduced motion.
+*/
+
+/* --- Checkmark draw-in --- */
+@keyframes checkmark-draw {
+  from {
+    stroke-dashoffset: 24;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.animate-checkmark-draw {
+  stroke-dasharray: 24;
+  stroke-dashoffset: 24;
+  animation: checkmark-draw 250ms ease-out forwards;
+}
+
+/* --- Checkbox pop: scale bounce for the check container --- */
+@keyframes checkbox-pop {
+  0% {
+    transform: scale(0.8);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.animate-checkbox-pop {
+  animation: checkbox-pop 200ms ease-out;
+}
+
+/* --- Badge unlock: scale up + settle with glow pulse --- */
+@keyframes badge-unlock {
+  0% {
+    transform: scale(0.6);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes badge-glow {
+  0%, 100% {
+    box-shadow: 0 0 16px rgba(139, 92, 246, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(139, 92, 246, 0.5);
+  }
+}
+
+.animate-badge-unlock {
+  animation: badge-unlock 350ms ease-out;
+}
+
+.animate-badge-glow {
+  animation: badge-glow 600ms ease-in-out;
+}
+
+/* --- Card press feedback (active state) --- */
+.animate-card-press {
+  transition: transform 150ms ease-out;
+}
+
+.animate-card-press:active {
+  transform: scale(0.98);
+}
+
+/* --- Tab content crossfade --- */
+@keyframes tab-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-tab-enter {
+  animation: tab-fade-in 200ms ease-out;
+}
+
+/* --- Routine completion celebration (CSS-only sparkles) --- */
+@keyframes sparkle-drift-1 {
+  0% {
+    transform: translate(0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-20px, -30px) scale(1);
+    opacity: 0;
+  }
+}
+
+@keyframes sparkle-drift-2 {
+  0% {
+    transform: translate(0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(22px, -28px) scale(1);
+    opacity: 0;
+  }
+}
+
+@keyframes sparkle-drift-3 {
+  0% {
+    transform: translate(0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-14px, -36px) scale(1);
+    opacity: 0;
+  }
+}
+
+@keyframes sparkle-drift-4 {
+  0% {
+    transform: translate(0, 0) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(18px, -32px) scale(1);
+    opacity: 0;
+  }
+}
+
+.celebration-container {
+  position: relative;
+}
+
+.celebration-container .sparkle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+/* nth-child offsets account for button being the first child */
+.celebration-container .sparkle:nth-child(2) {
+  top: 0;
+  left: 30%;
+  background: var(--color-amber-400);
+  animation: sparkle-drift-1 400ms ease-out forwards;
+}
+
+.celebration-container .sparkle:nth-child(3) {
+  top: 0;
+  left: 60%;
+  background: var(--color-emerald-400);
+  animation: sparkle-drift-2 400ms ease-out 50ms forwards;
+}
+
+.celebration-container .sparkle:nth-child(4) {
+  top: 0;
+  left: 20%;
+  background: var(--color-violet-400);
+  animation: sparkle-drift-3 400ms ease-out 100ms forwards;
+}
+
+.celebration-container .sparkle:nth-child(5) {
+  top: 0;
+  left: 70%;
+  background: var(--color-amber-500);
+  animation: sparkle-drift-4 400ms ease-out 75ms forwards;
+}
+
+/* --- Approval card slide-out (GPU-composited: transform + opacity only) --- */
+@keyframes slide-out-left {
+  from {
+    transform: translateX(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-100%);
+    opacity: 0;
+  }
+}
+
+.animate-slide-out {
+  animation: slide-out-left 300ms ease-in forwards;
+}
+
+/* --- Reduced motion: disable everything --- */
+@media (prefers-reduced-motion: reduce) {
+  .animate-checkmark-draw,
+  .animate-checkbox-pop,
+  .animate-badge-unlock,
+  .animate-badge-glow,
+  .animate-tab-enter,
+  .animate-slide-out,
+  .celebration-container .sparkle {
+    animation: none !important;
+  }
+
+  .animate-card-press:active {
+    transform: none !important;
+  }
+
+  .animate-checkmark-draw {
+    stroke-dashoffset: 0;
+    stroke-dasharray: none;
+  }
+}

--- a/packages/client/src/styles/globals.css
+++ b/packages/client/src/styles/globals.css
@@ -1,3 +1,5 @@
+@import "./animations.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
## Summary

- Adds `animations.css` with keyframes and a global `prefers-reduced-motion` media query that disables all animations for users who prefer reduced motion
- Checkmark draw animation on checklist item completion (CSS stroke-dashoffset transition)
- Routine completion celebration with sparkle particles and a brief overlay
- Badge unlock scale + glow animation for newly earned badges, with ref tracking moved from `useMemo` to `useEffect` to fix a Strict Mode side-effect
- Tab content crossfade transition via a `TabContent` wrapper keyed on the active route segment
- Card press feedback (subtle scale on active state) on interactive cards
- Animated points counter via `useAnimatedNumber` hook using `requestAnimationFrame`
- Approval card slide-out animation on approve/reject with `onSuccess` callback

## Scope

Milestone 5, Task 5.5 (Animations and Transitions).

**New files:**
- `packages/client/src/styles/animations.css`
- `packages/client/src/hooks/useAnimatedNumber.ts`

**Modified:** `App.tsx`, `BadgeCollection.tsx`, `BadgeIcon.tsx`, `ApprovalsScreen.tsx`, `MeScreen.tsx`, `PointsDisplay.tsx`, `RewardCard.tsx`, `ChecklistItem.tsx`, `RoutineChecklist.tsx`, `globals.css`

12 files changed, +377 / -34

## Test plan

- [ ] Checking a checklist item shows a checkmark animation
- [ ] Completing a routine shows a brief celebration animation
- [ ] Badge unlock shows a reveal animation with visual emphasis
- [ ] Tab switching has smooth crossfade transition
- [ ] Cards respond to tap with subtle press feedback
- [ ] Points changing shows a number roll animation
- [ ] Approval cards slide out on approve/reject
- [ ] All animations respect `prefers-reduced-motion` (disabled when user prefers reduced motion)
- [ ] Animation durations are short (150-400ms) and don't block interaction
- [ ] No layout shifts or jank from animations
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm run test -- --run` passes (848 tests, 65 files)