### PR TITLE
Remove redundant getLedger from pointsService

### DIFF
--- a/packages/server/src/routes/child.ts
+++ b/packages/server/src/routes/child.ts
@@ -74,7 +74,7 @@ export function createChildRoutes(
     try {
       const limit = Math.min(Math.max(Number(req.query.limit) || 10, 1), 100);
       const offset = Math.max(Number(req.query.offset) || 0, 0);
-      const entries = pointsService.getLedger({ limit, offset });
+      const entries = pointsService.getLedgerFiltered({ limit, offset });
       res.json({ data: entries });
     } catch (err) {
       next(err);

--- a/packages/server/src/services/pointsService.ts
+++ b/packages/server/src/services/pointsService.ts
@@ -5,7 +5,6 @@ import type { ActivityService } from "./activityService.js";
 
 export interface PointsService {
   getBalance(): PointsBalance;
-  getLedger(options: { limit: number; offset: number }): LedgerEntry[];
   getLedgerFiltered(options: { limit: number; offset: number; entryType?: EntryType }): LedgerEntry[];
   createAdjustment(amount: number, note: string): LedgerEntry;
 }
@@ -76,13 +75,6 @@ export function createPointsService(db: Database.Database, activityService: Acti
     return { total, reserved, available: total - reserved };
   }
 
-  function getLedger(options: { limit: number; offset: number }): LedgerEntry[] {
-    const safeLimit = Math.max(1, Math.min(options.limit, 100));
-    const safeOffset = Math.max(0, options.offset);
-    const rows = selectLedgerStmt.all(safeLimit, safeOffset) as LedgerRow[];
-    return rows.map(mapLedgerRow);
-  }
-
   function getLedgerFiltered(options: { limit: number; offset: number; entryType?: EntryType }): LedgerEntry[] {
     const safeLimit = Math.max(1, Math.min(options.limit, 100));
     const safeOffset = Math.max(0, options.offset);
@@ -128,5 +120,5 @@ export function createPointsService(db: Database.Database, activityService: Acti
     return createAdjustmentTx(amount, trimmedNote);
   }
 
-  return { getBalance, getLedger, getLedgerFiltered, createAdjustment };
+  return { getBalance, getLedgerFiltered, createAdjustment };
 }

--- a/packages/server/tests/services/pointsService.test.ts
+++ b/packages/server/tests/services/pointsService.test.ts
@@ -90,13 +90,13 @@ describe('pointsService', () => {
     });
   });
 
-  describe('getLedger', () => {
+  describe('getLedgerFiltered', () => {
     it('returns entries in descending date order', () => {
       seedPointsLedger(db, 10);
       seedPointsLedger(db, 20);
       seedPointsLedger(db, 30);
 
-      const entries = service.getLedger({ limit: 10, offset: 0 });
+      const entries = service.getLedgerFiltered({ limit: 10, offset: 0 });
 
       expect(entries).toHaveLength(3);
       expect(entries[0].amount).toBe(30);
@@ -108,8 +108,8 @@ describe('pointsService', () => {
         seedPointsLedger(db, i * 10);
       }
 
-      const page1 = service.getLedger({ limit: 2, offset: 0 });
-      const page2 = service.getLedger({ limit: 2, offset: 2 });
+      const page1 = service.getLedgerFiltered({ limit: 2, offset: 0 });
+      const page2 = service.getLedgerFiltered({ limit: 2, offset: 2 });
 
       expect(page1).toHaveLength(2);
       expect(page2).toHaveLength(2);
@@ -120,7 +120,7 @@ describe('pointsService', () => {
     it('returns correct fields', () => {
       seedPointsLedger(db, 42);
 
-      const entries = service.getLedger({ limit: 10, offset: 0 });
+      const entries = service.getLedgerFiltered({ limit: 10, offset: 0 });
 
       expect(entries).toHaveLength(1);
       expect(entries[0].entryType).toBe('manual');
@@ -134,7 +134,7 @@ describe('pointsService', () => {
         seedPointsLedger(db, i);
       }
 
-      const entries = service.getLedger({ limit: 200, offset: 0 });
+      const entries = service.getLedgerFiltered({ limit: 200, offset: 0 });
 
       expect(entries).toHaveLength(5);
     });


### PR DESCRIPTION
## Problem

`pointsService.ts` exposes two ledger query methods: `getLedger` (limit/offset only) and `getLedgerFiltered` (limit/offset + optional `entryType`). When `entryType` is omitted, `getLedgerFiltered` produces identical behavior to `getLedger` -- same prepared statement, same parameter clamping, same row mapping. The redundant method adds surface area to the `PointsService` interface without providing any distinct capability.

Found during code simplicity review of PR #63.

## Changes

- Remove `getLedger` from the `PointsService` interface (1 line)
- Remove `getLedger` function implementation (~6 lines)
- Remove `getLedger` from the factory return object
- Update `child.ts` route to call `getLedgerFiltered({ limit, offset })` instead of `getLedger({ limit, offset })`
- Update `pointsService.test.ts` describe block and 4 test calls from `getLedger` to `getLedgerFiltered`

No behavior change -- `getLedgerFiltered` without `entryType` hits the same `selectLedgerStmt` that `getLedger` used.

## Test plan

1. Run `npm run typecheck` -- verify no type errors from removed interface method
2. Run `npm run test -- --run` -- verify all `getLedgerFiltered` tests pass (descending order, pagination, correct fields, limit cap)
3. Hit `GET /api/child/points/ledger?limit=10&offset=0` -- verify it returns ledger entries identically to before
4. Hit `GET /api/admin/points/ledger?entry_type=chore_completion` -- verify filtered queries still work
5. Verify that no other callers reference `getLedger` (confirmed via `rg`)

Closes #69