### PR TITLE
Consolidate dual-mapper pairs in domain services

### DIFF
--- a/packages/server/src/services/choreService.ts
+++ b/packages/server/src/services/choreService.ts
@@ -80,33 +80,11 @@ function mapChoreRow(row: ChoreRow): Chore {
     requiresApproval: row.requires_approval === 1,
     sortOrder: row.sort_order,
     tiers: [],
-  };
-}
-
-function mapTierRow(row: TierRow): ChoreTier {
-  return {
-    id: row.id,
-    choreId: row.chore_id,
-    name: row.name,
-    points: row.points,
-    sortOrder: row.sort_order,
-  };
-}
-
-type AdminTierRow = TierRow;
-
-function mapChoreRowAdmin(row: ChoreRow): Chore {
-  return {
-    id: row.id,
-    name: row.name,
-    requiresApproval: row.requires_approval === 1,
-    sortOrder: row.sort_order,
-    tiers: [],
     archivedAt: row.archived_at ?? undefined,
   };
 }
 
-function mapTierRowAdmin(row: AdminTierRow): ChoreTier {
+function mapTierRow(row: TierRow): ChoreTier {
   return {
     id: row.id,
     choreId: row.chore_id,
@@ -420,7 +398,7 @@ export function createChoreService(
 
   function listChoresAdmin(): Chore[] {
     const rows = selectAllChoresStmt.all() as ChoreRow[];
-    const allTierRows = selectAllTiersAdminBulkStmt.all() as AdminTierRow[];
+    const allTierRows = selectAllTiersAdminBulkStmt.all() as TierRow[];
 
     const tiersByChoreId = new Map<number, ChoreTier[]>();
     for (const tierRow of allTierRows) {
@@ -429,11 +407,11 @@ export function createChoreService(
         tiers = [];
         tiersByChoreId.set(tierRow.chore_id, tiers);
       }
-      tiers.push(mapTierRowAdmin(tierRow));
+      tiers.push(mapTierRow(tierRow));
     }
 
     return rows.map((row) => {
-      const chore = mapChoreRowAdmin(row);
+      const chore = mapChoreRow(row);
       chore.tiers = tiersByChoreId.get(row.id) ?? [];
       return chore;
     });
@@ -444,9 +422,9 @@ export function createChoreService(
     if (!row) {
       throw new NotFoundError("Chore not found");
     }
-    const chore = mapChoreRowAdmin(row);
-    const tierRows = selectAllTiersForChoreStmt.all(id) as AdminTierRow[];
-    chore.tiers = tierRows.map(mapTierRowAdmin);
+    const chore = mapChoreRow(row);
+    const tierRows = selectAllTiersForChoreStmt.all(id) as TierRow[];
+    chore.tiers = tierRows.map(mapTierRow);
     return chore;
   }
 
@@ -543,7 +521,7 @@ export function createChoreService(
       }
     }
 
-    const remainingTiers = selectAllTiersForChoreStmt.all(id) as AdminTierRow[];
+    const remainingTiers = selectAllTiersForChoreStmt.all(id) as TierRow[];
     const activeTierCount = remainingTiers.filter((t) => t.archived_at === null).length;
     if (activeTierCount === 0) {
       throw new ValidationError("A chore must have at least one active tier");

--- a/packages/server/src/services/rewardService.ts
+++ b/packages/server/src/services/rewardService.ts
@@ -67,17 +67,6 @@ function mapRewardRow(row: RewardRow): Reward {
     imageAssetId: row.image_asset_id ?? undefined,
     imageUrl: row.asset_stored_filename ? `/assets/${row.asset_stored_filename}` : undefined,
     sortOrder: row.sort_order,
-  };
-}
-
-function mapRewardRowAdmin(row: RewardRow): Reward {
-  return {
-    id: row.id,
-    name: row.name,
-    pointsCost: row.points_cost,
-    imageAssetId: row.image_asset_id ?? undefined,
-    imageUrl: row.asset_stored_filename ? `/assets/${row.asset_stored_filename}` : undefined,
-    sortOrder: row.sort_order,
     archivedAt: row.archived_at ?? undefined,
   };
 }
@@ -313,7 +302,7 @@ export function createRewardService(
 
   function listRewardsAdmin(): Reward[] {
     const rows = selectAllRewardsStmt.all() as RewardRow[];
-    return rows.map(mapRewardRowAdmin);
+    return rows.map(mapRewardRow);
   }
 
   function getRewardAdmin(id: number): Reward {
@@ -321,7 +310,7 @@ export function createRewardService(
     if (!row) {
       throw new NotFoundError("Reward not found");
     }
-    return mapRewardRowAdmin(row);
+    return mapRewardRow(row);
   }
 
   const createRewardTx = db.transaction((data: CreateRewardData): Reward => {

--- a/packages/server/src/services/routineService.ts
+++ b/packages/server/src/services/routineService.ts
@@ -81,6 +81,7 @@ interface ChecklistItemRow {
   image_asset_id: number | null;
   asset_stored_filename: string | null;
   sort_order: number;
+  archived_at: string | null;
 }
 
 interface CompletionRow {
@@ -113,42 +114,11 @@ function mapRoutineRow(row: RoutineRow): Routine {
     randomizeItems: row.randomize_items === 1,
     sortOrder: row.sort_order,
     items: [],
-  };
-}
-
-function mapChecklistItemRow(row: ChecklistItemRow): ChecklistItem {
-  return {
-    id: row.id,
-    routineId: row.routine_id,
-    label: row.label,
-    imageAssetId: row.image_asset_id ?? undefined,
-    imageUrl: row.asset_stored_filename ? `/assets/${row.asset_stored_filename}` : undefined,
-    sortOrder: row.sort_order,
-  };
-}
-
-interface AdminChecklistItemRow extends ChecklistItemRow {
-  archived_at: string | null;
-}
-
-function mapRoutineRowAdmin(row: RoutineRow): Routine {
-  return {
-    id: row.id,
-    name: row.name,
-    timeSlot: row.time_slot as TimeSlot,
-    completionRule: row.completion_rule as CompletionRule,
-    points: row.points,
-    requiresApproval: row.requires_approval === 1,
-    imageAssetId: row.image_asset_id ?? undefined,
-    imageUrl: row.asset_stored_filename ? `/assets/${row.asset_stored_filename}` : undefined,
-    randomizeItems: row.randomize_items === 1,
-    sortOrder: row.sort_order,
-    items: [],
     archivedAt: row.archived_at ?? undefined,
   };
 }
 
-function mapChecklistItemRowAdmin(row: AdminChecklistItemRow): ChecklistItem {
+function mapChecklistItemRow(row: ChecklistItemRow): ChecklistItem {
   return {
     id: row.id,
     routineId: row.routine_id,
@@ -197,7 +167,7 @@ export function createRoutineService(
 
   const selectActiveItemsStmt = db.prepare(
     `SELECT ci.id, ci.routine_id, ci.label, ci.image_asset_id,
-            a.stored_filename AS asset_stored_filename, ci.sort_order
+            a.stored_filename AS asset_stored_filename, ci.sort_order, ci.archived_at
      FROM checklist_items ci
      LEFT JOIN assets a ON ci.image_asset_id = a.id
      WHERE ci.routine_id = ? AND ci.active = 1 AND ci.archived_at IS NULL
@@ -206,7 +176,7 @@ export function createRoutineService(
 
   const selectAllActiveItemsStmt = db.prepare(
     `SELECT ci.id, ci.routine_id, ci.label, ci.image_asset_id,
-            a.stored_filename AS asset_stored_filename, ci.sort_order
+            a.stored_filename AS asset_stored_filename, ci.sort_order, ci.archived_at
      FROM checklist_items ci
      INNER JOIN routines r ON ci.routine_id = r.id
      LEFT JOIN assets a ON ci.image_asset_id = a.id
@@ -485,7 +455,7 @@ export function createRoutineService(
 
   function listRoutinesAdmin(): Routine[] {
     const rows = selectAllRoutinesStmt.all() as RoutineRow[];
-    const allItemRows = selectAllItemsAdminBulkStmt.all() as AdminChecklistItemRow[];
+    const allItemRows = selectAllItemsAdminBulkStmt.all() as ChecklistItemRow[];
 
     const itemsByRoutineId = new Map<number, ChecklistItem[]>();
     for (const itemRow of allItemRows) {
@@ -494,11 +464,11 @@ export function createRoutineService(
         items = [];
         itemsByRoutineId.set(itemRow.routine_id, items);
       }
-      items.push(mapChecklistItemRowAdmin(itemRow));
+      items.push(mapChecklistItemRow(itemRow));
     }
 
     return rows.map((row) => {
-      const routine = mapRoutineRowAdmin(row);
+      const routine = mapRoutineRow(row);
       routine.items = itemsByRoutineId.get(row.id) ?? [];
       return routine;
     });
@@ -509,9 +479,9 @@ export function createRoutineService(
     if (!row) {
       throw new NotFoundError("Routine not found");
     }
-    const routine = mapRoutineRowAdmin(row);
-    const itemRows = selectAllItemsForRoutineStmt.all(id) as AdminChecklistItemRow[];
-    routine.items = itemRows.map(mapChecklistItemRowAdmin);
+    const routine = mapRoutineRow(row);
+    const itemRows = selectAllItemsForRoutineStmt.all(id) as ChecklistItemRow[];
+    routine.items = itemRows.map(mapChecklistItemRow);
     return routine;
   }
 


### PR DESCRIPTION
## Summary

Three service files (routineService, choreService, rewardService) each defined two nearly-identical mapper functions -- one for child views and one for admin. The only difference was the presence of `archivedAt`. Since child-facing queries filter archived records at the SQL level (`WHERE archived_at IS NULL`), the admin-only mappers were unnecessary duplication.

This PR merges each mapper pair into a single function that always includes `archivedAt: row.archived_at ?? undefined`. For child views, `archivedAt` is always `undefined` since the SQL filters guarantee no archived rows are returned.

## Changes

- **routineService.ts**: Merge `mapRoutineRowAdmin` into `mapRoutineRow`, merge `mapChecklistItemRowAdmin` into `mapChecklistItemRow`, remove `AdminChecklistItemRow` interface, add `archived_at` to `ChecklistItemRow` and child-facing item queries
- **choreService.ts**: Merge `mapChoreRowAdmin` into `mapChoreRow`, merge `mapTierRowAdmin` into `mapTierRow`, remove `AdminTierRow` type alias
- **rewardService.ts**: Merge `mapRewardRowAdmin` into `mapRewardRow`

Net result: 83 lines removed, 20 lines added (-63 lines).

## Test plan

1. Run `npm run typecheck` -- verify no type errors from the consolidated mappers
2. Run `npm run test -- --run --project server` -- verify all 625 server tests pass (existing tests cover both child and admin mapper paths)
3. Verify that admin list views still include `archivedAt` on archived entities
4. Verify that child-facing views return `archivedAt` as `undefined` for active entities
5. Verify that no `mapXxxAdmin`, `AdminChecklistItemRow`, or `AdminTierRow` references remain in the codebase

Closes #68