### PR TITLE
Navigate to homepage after routine completion

### DIFF
--- a/packages/client/src/features/child/routines/RoutineChecklist.tsx
+++ b/packages/client/src/features/child/routines/RoutineChecklist.tsx
@@ -67,7 +67,7 @@ export default function RoutineChecklist() {
         onSuccess: async () => {
           try { await deleteDraft(routine.id); } catch { /* IndexedDB unavailable */ }
           setIsShowingCelebration(true);
-          navigationTimeoutRef.current = setTimeout(() => navigate("/routines"), 800);
+          navigationTimeoutRef.current = setTimeout(() => navigate("/today"), 800);
         },
         onError: async (error: unknown) => {
           const apiError = error && typeof error === "object" && "code" in error

--- a/packages/client/tests/features/child/routines/RoutineChecklist.test.tsx
+++ b/packages/client/tests/features/child/routines/RoutineChecklist.test.tsx
@@ -25,6 +25,7 @@ function renderChecklist(routineId = 1) {
           <Routes>
             <Route path="/routines/:id" element={<RoutineChecklist />} />
             <Route path="/routines" element={<div data-testid="routines-page">Routines</div>} />
+            <Route path="/today" element={<div data-testid="today-page">Today</div>} />
           </Routes>
         </OnlineProvider>
       </MemoryRouter>
@@ -122,7 +123,7 @@ describe("RoutineChecklist", () => {
     expect(submitButton).toBeEnabled();
   });
 
-  it("navigates back to routines after successful submit", async () => {
+  it("navigates to homepage after successful submit", async () => {
     const user = userEvent.setup();
     renderChecklist(1);
 
@@ -132,7 +133,7 @@ describe("RoutineChecklist", () => {
     await user.click(screen.getByRole("button", { name: /complete routine/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("routines-page")).toBeInTheDocument();
+      expect(screen.getByTestId("today-page")).toBeInTheDocument();
     });
   });
 
@@ -146,7 +147,7 @@ describe("RoutineChecklist", () => {
     await user.click(screen.getByRole("button", { name: /complete routine/i }));
 
     await waitFor(() => {
-      expect(screen.getByTestId("routines-page")).toBeInTheDocument();
+      expect(screen.getByTestId("today-page")).toBeInTheDocument();
     });
 
     const draft = await getDraft(1);


### PR DESCRIPTION
## Summary

After completing a routine, the child stayed on the routine detail page with no clear next step. The homepage displays their total points, which is the primary motivator -- routing them there after completion closes the feedback loop so they immediately see the payoff.

- Change `onSuccess` navigation in `RoutineChecklist` from `/routines` to `/today`
- Error paths (archived routine, already completed) still navigate to `/routines` since the child didn't earn points
- Update test assertions to verify `/today` navigation on success

## Test plan

1. Complete a routine by checking all items and tapping "Complete Routine!"
   - Verify that after the celebration animation, the app navigates to the Today/homepage
   - Verify that the updated point total is visible
2. Trigger a 409 archived error (archive a routine mid-completion)
   - Verify that the toast shows and navigation goes to `/routines` (not `/today`)
3. Trigger a 409 already_completed error (submit a routine that was already done today)
   - Verify that the toast shows and navigation goes to `/routines` (not `/today`)

Closes #74