### PR TITLE
Make Complete Routine button sticky above bottom nav

### DIFF
--- a/packages/client/src/features/child/routines/RoutineChecklist.tsx
+++ b/packages/client/src/features/child/routines/RoutineChecklist.tsx
@@ -145,7 +145,7 @@ export default function RoutineChecklist() {
   const routineItemsById = new Map(routine.items.map((item) => [item.id, item]));
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--color-bg)]">
+    <div className="flex h-[calc(100dvh-4rem-env(safe-area-inset-bottom,0px))] flex-col bg-[var(--color-bg)]">
       <div aria-live="assertive" role="status" className="fixed left-4 right-4 top-4 z-50 pointer-events-none">
         {toastMessage && (
           <div className="rounded-2xl bg-[var(--color-text)] px-4 py-3 text-center font-medium text-white shadow-toast pointer-events-auto">
@@ -154,7 +154,7 @@ export default function RoutineChecklist() {
         )}
       </div>
 
-      <header className="sticky top-0 z-10 border-b border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_95%,transparent)] px-4 py-3 backdrop-blur">
+      <header className="shrink-0 z-10 border-b border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_95%,transparent)] px-4 py-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <Link
@@ -221,7 +221,7 @@ export default function RoutineChecklist() {
         })}
       </div>
 
-      <div className="sticky bottom-0 border-t border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_95%,transparent)] p-4 backdrop-blur">
+      <div className="shrink-0 border-t border-[var(--color-border)] bg-[color-mix(in_srgb,var(--color-surface)_95%,transparent)] p-4">
         {!isOnline && (
           <p className="mb-2 text-center text-sm font-medium text-[var(--color-amber-700)]">
             You're offline -- connect to submit.


### PR DESCRIPTION
## Summary

The "Complete Routine" button was positioned below the task list and could scroll off-screen or get hidden behind the bottom navigation bar. A child using the app wouldn't realize the button was there after checking off all tasks.

This PR constrains the checklist layout to fill exactly the viewport space above the bottom nav, so the task list scrolls independently and the submit button is always visible.

### Changes

- **Container height** (`RoutineChecklist.tsx`): Replaced `min-h-screen` with `h-[calc(100dvh-4rem-env(safe-area-inset-bottom,0px))]` to fit the content between the top of the viewport and the bottom nav bar. Uses `dvh` for correct behavior on iOS when the address bar hides/shows.
- **Header**: Changed from `sticky top-0` with `backdrop-blur` to `shrink-0` since the header is now outside the scroll area and doesn't need sticky positioning.
- **Button footer**: Changed from `sticky bottom-0` with `backdrop-blur` to `shrink-0` — the flex layout keeps it pinned at the bottom of the container without needing sticky positioning.

The task list (`flex-1 overflow-y-auto`) remains the only scrollable area, sandwiched between the fixed header and fixed footer.

## Test plan

1. Open a routine with many tasks (enough to overflow the screen)
2. Verify that the "Complete Routine" button is visible at the bottom without scrolling
3. Verify that the task list scrolls independently between the header and button
4. Check all tasks and verify the button enables and stays visible
5. Test on an iPad / iOS PWA to verify the `dvh` unit and safe area insets work correctly
6. Verify in landscape orientation that the layout still works
7. Verify that routines with few tasks still show the button at the bottom (no awkward gap)

### Accessibility checklist
- [ ] Button remains reachable via keyboard tab
- [ ] Progress bar and checklist items are still screen-reader accessible
- [ ] Touch targets remain at minimum 44x44px

Closes #73