### PR TITLE
Use bind mount for data volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - chore-data:/data
+      - ./data:/data
     env_file:
       - .env
     restart: unless-stopped
-
-volumes:
-  chore-data:


### PR DESCRIPTION
## Summary
- Switches `docker-compose.yml` from a Docker-managed named volume (`chore-data`) to a bind mount (`./data:/data`)
- Makes the SQLite database and log files directly accessible on the host at `./data/` for easy backups and inspection
- `data/` is already gitignored — no risk of committing runtime data

## Test plan
- [ ] `docker compose up -d --build` creates `./data/` directory automatically
- [ ] App starts and writes `chore.db` to `./data/`
- [ ] Container rebuild preserves existing data
- [ ] `docker compose down && docker compose up -d` preserves data

🤖 Generated with [Claude Code](https://claude.com/claude-code)