### PR TITLE
Extract shared query key constants and invalidation helpers

### DIFF
--- a/packages/client/src/features/admin/activity/ActivityLogScreen.tsx
+++ b/packages/client/src/features/admin/activity/ActivityLogScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import { useAdminTimezone } from "../hooks/useAdminTimezone.js";
 import { formatTimestamp } from "../../../lib/format-timestamp.js";
 import { ACTIVITY_EVENT_TYPES } from "@chore-app/shared";
@@ -81,7 +82,7 @@ export default function ActivityLogScreen() {
   const [page, setPage] = useState(0);
 
   const query = useQuery({
-    queryKey: ["admin", "activity-log", eventTypeFilter, startDate, endDate, page],
+    queryKey: queryKeys.admin.activityLog(eventTypeFilter, startDate, endDate, page),
     queryFn: async () => {
       const params = new URLSearchParams({
         page: String(page),

--- a/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
+++ b/packages/client/src/features/admin/approvals/ApprovalsScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import { useAdminTimezone } from "../hooks/useAdminTimezone.js";
 import { formatTimestamp } from "../../../lib/format-timestamp.js";
 import type {
@@ -14,7 +15,7 @@ import type {
 
 function usePendingApprovals(isOnline: boolean) {
   return useQuery({
-    queryKey: ["admin", "approvals"],
+    queryKey: queryKeys.admin.approvals(),
     queryFn: async () => {
       const result = await api.get<PendingApprovals>("/api/admin/approvals");
       if (!result.ok) throw result.error;
@@ -45,7 +46,7 @@ function useApproveItem() {
       if (!result.ok) throw result.error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "approvals"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.approvals() });
     },
   });
 }
@@ -70,7 +71,7 @@ function useRejectItem() {
       if (!result.ok) throw result.error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "approvals"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.approvals() });
     },
   });
 }

--- a/packages/client/src/features/admin/assets/AssetPicker.tsx
+++ b/packages/client/src/features/admin/assets/AssetPicker.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useId } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import type { Asset } from "@chore-app/shared";
 
 export interface AssetPickerProps {
@@ -108,7 +109,7 @@ export default function AssetPicker({ value, imageUrl, onChange, label }: AssetP
   const modelId = useId();
 
   const { data: assets, isLoading: isLoadingAssets } = useQuery({
-    queryKey: ["admin", "assets", { status: "active" }],
+    queryKey: queryKeys.admin.assets({ status: "active" }),
     queryFn: async () => {
       const result = await api.get<Asset[]>("/api/admin/assets?status=active");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/admin/chores/AdminChoreForm.tsx
+++ b/packages/client/src/features/admin/chores/AdminChoreForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import HelpTip from "../../../components/HelpTip.js";
 import type { Chore } from "@chore-app/shared";
 
@@ -35,7 +36,7 @@ const INITIAL_STATE: FormState = {
 
 function useExistingChore(id: string | undefined) {
   return useQuery({
-    queryKey: ["admin", "chores", id],
+    queryKey: queryKeys.admin.chore(id),
     queryFn: async () => {
       const result = await api.get<Chore>(`/api/admin/chores/${id}`);
       if (!result.ok) throw result.error;
@@ -106,7 +107,7 @@ export default function AdminChoreForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "chores"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.chores() });
       navigate("/admin/chores");
     },
   });
@@ -145,7 +146,7 @@ export default function AdminChoreForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "chores"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.chores() });
       navigate("/admin/chores");
     },
   });

--- a/packages/client/src/features/admin/chores/AdminChoresList.tsx
+++ b/packages/client/src/features/admin/chores/AdminChoresList.tsx
@@ -2,11 +2,12 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import type { Chore } from "@chore-app/shared";
 
 function useAdminChores() {
   return useQuery({
-    queryKey: ["admin", "chores"],
+    queryKey: queryKeys.admin.chores(),
     queryFn: async () => {
       const result = await api.get<Chore[]>("/api/admin/chores");
       if (!result.ok) throw result.error;
@@ -27,7 +28,7 @@ function useArchiveToggle() {
       if (!result.ok) throw result.error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "chores"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.chores() });
     },
   });
 }

--- a/packages/client/src/features/admin/hooks/useAdminTimezone.ts
+++ b/packages/client/src/features/admin/hooks/useAdminTimezone.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 
 interface SettingsResponse {
   [key: string]: string;
@@ -12,7 +13,7 @@ interface SettingsResponse {
  */
 export function useAdminTimezone(): string {
   const query = useQuery({
-    queryKey: ["admin", "settings"],
+    queryKey: queryKeys.admin.settings(),
     queryFn: async () => {
       const result = await api.get<SettingsResponse>("/api/admin/settings");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/admin/ledger/LedgerScreen.tsx
+++ b/packages/client/src/features/admin/ledger/LedgerScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import HelpTip from "../../../components/HelpTip.js";
 import { useAdminTimezone } from "../hooks/useAdminTimezone.js";
 import { formatTimestamp } from "../../../lib/format-timestamp.js";
@@ -33,7 +34,7 @@ function useLedger(filter: FilterType) {
   const [page, setPage] = useState(0);
 
   const query = useQuery({
-    queryKey: ["admin", "ledger", filter, page],
+    queryKey: queryKeys.admin.ledger(filter, page),
     queryFn: async () => {
       const params = new URLSearchParams({
         limit: String(PAGE_SIZE),
@@ -92,7 +93,7 @@ function useAdjustPoints() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "ledger"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.ledger() });
     },
   });
 }

--- a/packages/client/src/features/admin/rewards/AdminRewardForm.tsx
+++ b/packages/client/src/features/admin/rewards/AdminRewardForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import HelpTip from "../../../components/HelpTip.js";
 import AssetPicker from "../assets/AssetPicker.js";
 import type { Reward } from "@chore-app/shared";
@@ -31,7 +32,7 @@ const INITIAL_STATE: FormState = {
 
 function useExistingReward(id: string | undefined) {
   return useQuery({
-    queryKey: ["admin", "rewards", id],
+    queryKey: queryKeys.admin.reward(id),
     queryFn: async () => {
       const result = await api.get<Reward>(`/api/admin/rewards/${id}`);
       if (!result.ok) throw result.error;
@@ -95,7 +96,7 @@ export default function AdminRewardForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "rewards"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.rewards() });
       navigate("/admin/rewards");
     },
   });
@@ -112,7 +113,7 @@ export default function AdminRewardForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "rewards"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.rewards() });
       navigate("/admin/rewards");
     },
   });

--- a/packages/client/src/features/admin/rewards/AdminRewardsList.tsx
+++ b/packages/client/src/features/admin/rewards/AdminRewardsList.tsx
@@ -2,11 +2,12 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import type { Reward } from "@chore-app/shared";
 
 function useAdminRewards() {
   return useQuery({
-    queryKey: ["admin", "rewards"],
+    queryKey: queryKeys.admin.rewards(),
     queryFn: async () => {
       const result = await api.get<Reward[]>("/api/admin/rewards");
       if (!result.ok) throw result.error;
@@ -27,7 +28,7 @@ function useArchiveToggle() {
       if (!result.ok) throw result.error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "rewards"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.rewards() });
     },
   });
 }

--- a/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import HelpTip from "../../../components/HelpTip.js";
 import AssetPicker from "../assets/AssetPicker.js";
 import type { Routine, TimeSlot, CompletionRule } from "@chore-app/shared";
@@ -62,7 +63,7 @@ const COMPLETION_RULE_OPTIONS: { value: CompletionRule; label: string }[] = [
 
 function useExistingRoutine(id: string | undefined) {
   return useQuery({
-    queryKey: ["admin", "routines", id],
+    queryKey: queryKeys.admin.routine(id),
     queryFn: async () => {
       const result = await api.get<Routine>(`/api/admin/routines/${id}`);
       if (!result.ok) throw result.error;
@@ -154,7 +155,7 @@ export default function AdminRoutineForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "routines"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.routines() });
     },
   });
 
@@ -193,7 +194,7 @@ export default function AdminRoutineForm() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "routines"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.routines() });
     },
   });
 

--- a/packages/client/src/features/admin/routines/AdminRoutinesList.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutinesList.tsx
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import type { Routine } from "@chore-app/shared";
 
 const TIME_SLOT_LABELS: Record<string, string> = {
@@ -19,7 +20,7 @@ const COMPLETION_RULE_LABELS: Record<string, string> = {
 
 function useAdminRoutines() {
   return useQuery({
-    queryKey: ["admin", "routines"],
+    queryKey: queryKeys.admin.routines(),
     queryFn: async () => {
       const result = await api.get<Routine[]>("/api/admin/routines");
       if (!result.ok) throw result.error;
@@ -40,7 +41,7 @@ function useArchiveToggle() {
       if (!result.ok) throw result.error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "routines"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.routines() });
     },
   });
 }

--- a/packages/client/src/features/admin/settings/SettingsScreen.tsx
+++ b/packages/client/src/features/admin/settings/SettingsScreen.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { PIN_MIN_LENGTH } from "@chore-app/shared";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys } from "../../../lib/query-keys.js";
 import HelpTip from "../../../components/HelpTip.js";
 import BackupSettings from "./BackupSettings.js";
 import NotificationSettings from "./NotificationSettings.js";
@@ -46,7 +47,7 @@ export default function SettingsScreen() {
   const queryClient = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["admin", "settings"],
+    queryKey: queryKeys.admin.settings(),
     queryFn: async () => {
       const result = await api.get<SettingsResponse>("/api/admin/settings");
       if (!result.ok) throw result.error;
@@ -95,7 +96,7 @@ export default function SettingsScreen() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["admin", "settings"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.settings() });
     },
   };
 

--- a/packages/client/src/features/child/chores/QuickChoreLog.tsx
+++ b/packages/client/src/features/child/chores/QuickChoreLog.tsx
@@ -6,6 +6,7 @@ import { useCancelChoreLog } from "./hooks/useCancelChoreLog.js";
 import { useChoreLogStatus } from "./hooks/useChoreLogStatus.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
 import { formatLocalDate } from "../../../lib/draft-sync.js";
+import { invalidatePointsRelated } from "../../../lib/query-keys.js";
 import type { Chore, ChoreTier, ChoreLog } from "@chore-app/shared";
 
 export default function QuickChoreLog() {
@@ -25,9 +26,7 @@ export default function QuickChoreLog() {
   useEffect(() => {
     if (polledLog && polledLog.status !== "pending") {
       setRecentLog(polledLog);
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
-      queryClient.invalidateQueries({ queryKey: ["points"] });
-      queryClient.invalidateQueries({ queryKey: ["ledger"] });
+      invalidatePointsRelated(queryClient);
     }
   }, [polledLog, queryClient]);
 

--- a/packages/client/src/features/child/chores/hooks/useCancelChoreLog.ts
+++ b/packages/client/src/features/child/chores/hooks/useCancelChoreLog.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { ChoreLog } from "@chore-app/shared";
 
 export function useCancelChoreLog() {
@@ -12,8 +13,8 @@ export function useCancelChoreLog() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["chores"] });
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.chores() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.bootstrap() });
     },
   });
 }

--- a/packages/client/src/features/child/chores/hooks/useChoreLogStatus.ts
+++ b/packages/client/src/features/child/chores/hooks/useChoreLogStatus.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { ChoreLog } from "@chore-app/shared";
 import { useOnline } from "../../../../contexts/OnlineContext.js";
 
@@ -10,7 +11,7 @@ export function useChoreLogStatus(logId: number | null) {
   const isEnabled = logId !== null && isOnline;
 
   return useQuery({
-    queryKey: ["chore-log", logId],
+    queryKey: queryKeys.choreLog(logId),
     queryFn: async () => {
       const result = await api.get<ChoreLog>(`/api/chore-logs/${logId}`);
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/chores/hooks/useChores.ts
+++ b/packages/client/src/features/child/chores/hooks/useChores.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { Chore } from "@chore-app/shared";
 
 export function useChores() {
   return useQuery({
-    queryKey: ["chores"],
+    queryKey: queryKeys.chores(),
     queryFn: async () => {
       const result = await api.get<Chore[]>("/api/chores");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/chores/hooks/useSubmitChoreLog.ts
+++ b/packages/client/src/features/child/chores/hooks/useSubmitChoreLog.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { invalidatePointsRelated } from "../../../../lib/query-keys.js";
 import type { ChoreLog } from "@chore-app/shared";
 
 interface SubmitChoreLogPayload {
@@ -19,9 +20,7 @@ export function useSubmitChoreLog() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
-      queryClient.invalidateQueries({ queryKey: ["points"] });
-      queryClient.invalidateQueries({ queryKey: ["ledger"] });
+      invalidatePointsRelated(queryClient);
     },
   });
 }

--- a/packages/client/src/features/child/me/hooks/useBadges.ts
+++ b/packages/client/src/features/child/me/hooks/useBadges.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { Badge } from "@chore-app/shared";
 
 export function useBadges() {
   return useQuery({
-    queryKey: ["badges"],
+    queryKey: queryKeys.badges(),
     queryFn: async () => {
       const result = await api.get<Badge[]>("/api/badges");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/me/hooks/useRecentActivity.ts
+++ b/packages/client/src/features/child/me/hooks/useRecentActivity.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { ActivityEvent } from "@chore-app/shared";
 
 export function useRecentActivity(limit = 20) {
   return useQuery({
-    queryKey: ["activity", limit],
+    queryKey: queryKeys.activity(limit),
     queryFn: async () => {
       const result = await api.get<ActivityEvent[]>(
         `/api/activity/recent?limit=${limit}`,

--- a/packages/client/src/features/child/rewards/hooks/useCancelRewardRequest.ts
+++ b/packages/client/src/features/child/rewards/hooks/useCancelRewardRequest.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { invalidateBootstrapAndPoints } from "../../../../lib/query-keys.js";
 import type { RewardRequest } from "@chore-app/shared";
 
 export function useCancelRewardRequest() {
@@ -14,8 +15,7 @@ export function useCancelRewardRequest() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["points"] });
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
+      invalidateBootstrapAndPoints(queryClient);
     },
   });
 }

--- a/packages/client/src/features/child/rewards/hooks/useLedger.ts
+++ b/packages/client/src/features/child/rewards/hooks/useLedger.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { LedgerEntry } from "@chore-app/shared";
 
 export function useLedger(options: { limit?: number; offset?: number } = {}) {
@@ -7,7 +8,7 @@ export function useLedger(options: { limit?: number; offset?: number } = {}) {
   const offset = options.offset ?? 0;
 
   return useQuery({
-    queryKey: ["ledger", limit, offset],
+    queryKey: queryKeys.ledger(limit, offset),
     queryFn: async () => {
       const result = await api.get<LedgerEntry[]>(
         `/api/points/ledger?limit=${limit}&offset=${offset}`,

--- a/packages/client/src/features/child/rewards/hooks/usePoints.ts
+++ b/packages/client/src/features/child/rewards/hooks/usePoints.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { PointsBalance } from "@chore-app/shared";
 
 export function usePoints() {
   return useQuery({
-    queryKey: ["points"],
+    queryKey: queryKeys.points(),
     queryFn: async () => {
       const result = await api.get<PointsBalance>("/api/points/summary");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/rewards/hooks/useRewards.ts
+++ b/packages/client/src/features/child/rewards/hooks/useRewards.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { Reward } from "@chore-app/shared";
 
 export function useRewards() {
   return useQuery({
-    queryKey: ["rewards"],
+    queryKey: queryKeys.rewards(),
     queryFn: async () => {
       const result = await api.get<Reward[]>("/api/rewards");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/rewards/hooks/useSubmitRewardRequest.ts
+++ b/packages/client/src/features/child/rewards/hooks/useSubmitRewardRequest.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { invalidateBootstrapAndPoints } from "../../../../lib/query-keys.js";
 import type { RewardRequest } from "@chore-app/shared";
 
 interface SubmitRewardRequestPayload {
@@ -21,8 +22,7 @@ export function useSubmitRewardRequest() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["points"] });
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
+      invalidateBootstrapAndPoints(queryClient);
     },
   });
 }

--- a/packages/client/src/features/child/routines/hooks/useRoutine.ts
+++ b/packages/client/src/features/child/routines/hooks/useRoutine.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { Routine } from "@chore-app/shared";
 
 export function useRoutine(id: number | undefined) {
   return useQuery({
-    queryKey: ["routines", id],
+    queryKey: queryKeys.routine(id),
     queryFn: async () => {
       const result = await api.get<Routine>(`/api/routines/${id}`);
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/routines/hooks/useRoutines.ts
+++ b/packages/client/src/features/child/routines/hooks/useRoutines.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { Routine } from "@chore-app/shared";
 
 export function useRoutines() {
   return useQuery({
-    queryKey: ["routines"],
+    queryKey: queryKeys.routines(),
     queryFn: async () => {
       const result = await api.get<Routine[]>("/api/routines");
       if (!result.ok) throw result.error;

--- a/packages/client/src/features/child/routines/hooks/useSubmitRoutine.ts
+++ b/packages/client/src/features/child/routines/hooks/useSubmitRoutine.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { RoutineCompletion } from "@chore-app/shared";
 
 interface SubmitRoutinePayload {
@@ -23,8 +24,8 @@ export function useSubmitRoutine() {
       return result.data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["routines"] });
-      queryClient.invalidateQueries({ queryKey: ["bootstrap"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.routines() });
+      queryClient.invalidateQueries({ queryKey: queryKeys.bootstrap() });
     },
   });
 }

--- a/packages/client/src/features/child/today/hooks/useBootstrap.ts
+++ b/packages/client/src/features/child/today/hooks/useBootstrap.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../../../api/client.js";
+import { queryKeys } from "../../../../lib/query-keys.js";
 import type { BootstrapData } from "@chore-app/shared";
 
 export function useBootstrap() {
   return useQuery({
-    queryKey: ["bootstrap"],
+    queryKey: queryKeys.bootstrap(),
     queryFn: async () => {
       const result = await api.get<BootstrapData>("/api/app/bootstrap");
       if (!result.ok) throw result.error;

--- a/packages/client/src/lib/query-keys.ts
+++ b/packages/client/src/lib/query-keys.ts
@@ -1,0 +1,50 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+export const queryKeys = {
+  bootstrap: () => ["bootstrap"] as const,
+  points: () => ["points"] as const,
+  ledger: (limit?: number, offset?: number) =>
+    limit !== undefined ? (["ledger", limit, offset] as const) : (["ledger"] as const),
+  chores: () => ["chores"] as const,
+  choreLog: (logId: number | null) => ["chore-log", logId] as const,
+  routines: () => ["routines"] as const,
+  routine: (id: number | undefined) => ["routines", id] as const,
+  rewards: () => ["rewards"] as const,
+  badges: () => ["badges"] as const,
+  activity: (limit?: number) =>
+    limit !== undefined ? (["activity", limit] as const) : (["activity"] as const),
+
+  admin: {
+    settings: () => ["admin", "settings"] as const,
+    approvals: () => ["admin", "approvals"] as const,
+    routines: () => ["admin", "routines"] as const,
+    routine: (id: string | undefined) => ["admin", "routines", id] as const,
+    chores: () => ["admin", "chores"] as const,
+    chore: (id: string | undefined) => ["admin", "chores", id] as const,
+    rewards: () => ["admin", "rewards"] as const,
+    reward: (id: string | undefined) => ["admin", "rewards", id] as const,
+    ledger: (filter?: string, page?: number) =>
+      filter !== undefined
+        ? (["admin", "ledger", filter, page] as const)
+        : (["admin", "ledger"] as const),
+    assets: (filters: Record<string, string>) =>
+      ["admin", "assets", filters] as const,
+    activityLog: (
+      eventType: string,
+      startDate: string,
+      endDate: string,
+      page: number,
+    ) => ["admin", "activity-log", eventType, startDate, endDate, page] as const,
+  },
+} as const;
+
+export function invalidatePointsRelated(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.bootstrap() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.points() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.ledger() });
+}
+
+export function invalidateBootstrapAndPoints(queryClient: QueryClient) {
+  queryClient.invalidateQueries({ queryKey: queryKeys.bootstrap() });
+  queryClient.invalidateQueries({ queryKey: queryKeys.points() });
+}

--- a/packages/client/tests/lib/query-keys.test.ts
+++ b/packages/client/tests/lib/query-keys.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  queryKeys,
+  invalidatePointsRelated,
+  invalidateBootstrapAndPoints,
+} from "../../src/lib/query-keys.js";
+import type { QueryClient } from "@tanstack/react-query";
+
+function createMockQueryClient(): QueryClient {
+  return {
+    invalidateQueries: vi.fn(),
+  } as unknown as QueryClient;
+}
+
+describe("queryKeys", () => {
+  describe("child-side keys", () => {
+    it("returns bootstrap key", () => {
+      expect(queryKeys.bootstrap()).toEqual(["bootstrap"]);
+    });
+
+    it("returns points key", () => {
+      expect(queryKeys.points()).toEqual(["points"]);
+    });
+
+    it("returns ledger key with parameters", () => {
+      expect(queryKeys.ledger(10, 0)).toEqual(["ledger", 10, 0]);
+    });
+
+    it("returns ledger prefix key without parameters", () => {
+      expect(queryKeys.ledger()).toEqual(["ledger"]);
+    });
+
+    it("returns chores key", () => {
+      expect(queryKeys.chores()).toEqual(["chores"]);
+    });
+
+    it("returns chore-log key with logId", () => {
+      expect(queryKeys.choreLog(42)).toEqual(["chore-log", 42]);
+    });
+
+    it("returns chore-log key with null logId", () => {
+      expect(queryKeys.choreLog(null)).toEqual(["chore-log", null]);
+    });
+
+    it("returns routines key", () => {
+      expect(queryKeys.routines()).toEqual(["routines"]);
+    });
+
+    it("returns routine key with id", () => {
+      expect(queryKeys.routine(5)).toEqual(["routines", 5]);
+    });
+
+    it("returns routine key with undefined id", () => {
+      expect(queryKeys.routine(undefined)).toEqual(["routines", undefined]);
+    });
+
+    it("returns rewards key", () => {
+      expect(queryKeys.rewards()).toEqual(["rewards"]);
+    });
+
+    it("returns badges key", () => {
+      expect(queryKeys.badges()).toEqual(["badges"]);
+    });
+
+    it("returns activity key with limit", () => {
+      expect(queryKeys.activity(20)).toEqual(["activity", 20]);
+    });
+
+    it("returns activity prefix key without limit", () => {
+      expect(queryKeys.activity()).toEqual(["activity"]);
+    });
+  });
+
+  describe("admin keys", () => {
+    it("returns admin settings key", () => {
+      expect(queryKeys.admin.settings()).toEqual(["admin", "settings"]);
+    });
+
+    it("returns admin approvals key", () => {
+      expect(queryKeys.admin.approvals()).toEqual(["admin", "approvals"]);
+    });
+
+    it("returns admin routines list key", () => {
+      expect(queryKeys.admin.routines()).toEqual(["admin", "routines"]);
+    });
+
+    it("returns admin routine detail key", () => {
+      expect(queryKeys.admin.routine("3")).toEqual(["admin", "routines", "3"]);
+    });
+
+    it("returns admin chores list key", () => {
+      expect(queryKeys.admin.chores()).toEqual(["admin", "chores"]);
+    });
+
+    it("returns admin chore detail key", () => {
+      expect(queryKeys.admin.chore("7")).toEqual(["admin", "chores", "7"]);
+    });
+
+    it("returns admin rewards list key", () => {
+      expect(queryKeys.admin.rewards()).toEqual(["admin", "rewards"]);
+    });
+
+    it("returns admin reward detail key", () => {
+      expect(queryKeys.admin.reward("2")).toEqual(["admin", "rewards", "2"]);
+    });
+
+    it("returns admin ledger key with filter and page", () => {
+      expect(queryKeys.admin.ledger("chore", 1)).toEqual([
+        "admin",
+        "ledger",
+        "chore",
+        1,
+      ]);
+    });
+
+    it("returns admin ledger prefix key without parameters", () => {
+      expect(queryKeys.admin.ledger()).toEqual(["admin", "ledger"]);
+    });
+
+    it("returns admin assets key with filters", () => {
+      expect(queryKeys.admin.assets({ status: "active" })).toEqual([
+        "admin",
+        "assets",
+        { status: "active" },
+      ]);
+    });
+
+    it("returns admin activity-log key", () => {
+      expect(
+        queryKeys.admin.activityLog("all", "2026-01-01", "2026-01-31", 0),
+      ).toEqual(["admin", "activity-log", "all", "2026-01-01", "2026-01-31", 0]);
+    });
+  });
+});
+
+describe("invalidatePointsRelated", () => {
+  it("invalidates bootstrap, points, and ledger queries", () => {
+    const queryClient = createMockQueryClient();
+
+    invalidatePointsRelated(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(3);
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["bootstrap"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["points"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["ledger"],
+    });
+  });
+});
+
+describe("invalidateBootstrapAndPoints", () => {
+  it("invalidates bootstrap and points queries", () => {
+    const queryClient = createMockQueryClient();
+
+    invalidateBootstrapAndPoints(queryClient);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(2);
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["bootstrap"],
+    });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["points"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Raw query key string arrays are duplicated across 28 hooks and components in the client package. The same invalidation sequences (bootstrap + points + ledger, bootstrap + points) are repeated in multiple mutation hooks. This makes it easy to miss a key when adding new mutations and creates drift risk as the app grows.

This PR centralizes all TanStack Query keys into a single `queryKeys` factory object and extracts two invalidation helpers for the most common combos:

- **`queryKeys`** object in `packages/client/src/lib/query-keys.ts` with methods for every domain (bootstrap, points, ledger, chores, choreLog, routines, routine, rewards, badges, activity) and an `admin` sub-object (settings, approvals, routines, routine, chores, chore, rewards, reward, ledger, assets, activityLog)
- **`invalidatePointsRelated(queryClient)`** invalidates bootstrap + points + ledger (used by `useSubmitChoreLog`, `QuickChoreLog`)
- **`invalidateBootstrapAndPoints(queryClient)`** invalidates bootstrap + points (used by `useSubmitRewardRequest`, `useCancelRewardRequest`)
- All 28 files with raw query key strings updated to import from `query-keys.ts`

This is a pure refactor with no behavior changes.

## Test plan

1. Run `npm run typecheck` -- verify no type errors
2. Run `npm run lint` -- verify no lint issues
3. Run `npm run test -- --run` -- verify all 1006 unit tests pass
4. Run `npm run test:e2e` -- verify E2E tests pass (no behavior changes)
5. Open the app and complete a chore log. Verify that points and bootstrap data refresh correctly after submission
6. Request a reward. Verify that points balance updates
7. Cancel a reward request. Verify that points balance updates
8. Complete a routine. Verify that routines list and bootstrap refresh
9. In admin, create/edit/archive a chore, routine, and reward. Verify lists refresh after each operation

Closes #71