### PR TITLE
Extract reusable StatusPill component for amber pill pattern

### DIFF
--- a/packages/client/src/components/StatusPill.tsx
+++ b/packages/client/src/components/StatusPill.tsx
@@ -1,0 +1,30 @@
+interface StatusPillProps {
+  children: React.ReactNode;
+  size?: "sm" | "md";
+  hasBorder?: boolean;
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: "px-2.5 py-0.5 text-[11px] font-bold",
+  md: "px-3 py-1 text-sm font-display font-bold",
+} as const;
+
+export default function StatusPill({
+  children,
+  size = "md",
+  hasBorder = false,
+  className = "",
+}: StatusPillProps) {
+  const borderClasses = hasBorder
+    ? "border border-[var(--color-amber-100)] bg-[var(--color-amber-50)]"
+    : "bg-[var(--color-amber-100)]";
+
+  return (
+    <span
+      className={`rounded-full text-[var(--color-amber-700)] ${borderClasses} ${SIZE_CLASSES[size]} ${className}`.trim()}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/client/src/features/child/chores/QuickChoreLog.tsx
+++ b/packages/client/src/features/child/chores/QuickChoreLog.tsx
@@ -7,6 +7,7 @@ import { useChoreLogStatus } from "./hooks/useChoreLogStatus.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
 import { formatLocalDate } from "../../../lib/draft-sync.js";
 import type { Chore, ChoreTier, ChoreLog } from "@chore-app/shared";
+import StatusPill from "../../../components/StatusPill.js";
 
 export default function QuickChoreLog() {
   const [isOpen, setIsOpen] = useState(false);
@@ -221,9 +222,9 @@ export default function QuickChoreLog() {
               className="flex w-full items-center justify-between rounded-xl bg-[var(--color-surface-muted)] px-4 py-3 text-left transition-all duration-200 hover:bg-[var(--color-emerald-50)] hover:ring-1 hover:ring-[var(--color-emerald-400)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               <span className="font-medium text-[var(--color-text-secondary)]">{tier.name}</span>
-              <span className="rounded-full bg-[var(--color-amber-100)] px-2.5 py-0.5 text-sm font-bold text-[var(--color-amber-700)]">
+              <StatusPill>
                 +{tier.points} pts
-              </span>
+              </StatusPill>
             </button>
           ))}
 

--- a/packages/client/src/features/child/rewards/RewardCard.tsx
+++ b/packages/client/src/features/child/rewards/RewardCard.tsx
@@ -4,6 +4,7 @@ import { formatLocalDate } from "../../../lib/draft-sync.js";
 import { useSubmitRewardRequest } from "./hooks/useSubmitRewardRequest.js";
 import { useCancelRewardRequest } from "./hooks/useCancelRewardRequest.js";
 import type { Reward, RewardRequest } from "@chore-app/shared";
+import StatusPill from "../../../components/StatusPill.js";
 
 interface RewardCardProps {
   reward: Reward;
@@ -61,9 +62,9 @@ export default function RewardCard({ reward, availablePoints, pendingRequest }: 
         )}
         <div className="flex items-center justify-between">
           <h3 className="font-display font-bold text-[var(--color-text)]">{reward.name}</h3>
-          <span className="rounded-full bg-[var(--color-amber-100)] px-2.5 py-0.5 text-xs font-bold text-[var(--color-amber-700)]">
+          <StatusPill size="sm">
             Pending
-          </span>
+          </StatusPill>
         </div>
         <p className="mt-1 text-sm text-[var(--color-text-muted)]">{reward.pointsCost} pts</p>
         <button

--- a/packages/client/src/features/child/routines/RoutineCard.tsx
+++ b/packages/client/src/features/child/routines/RoutineCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { Routine } from "@chore-app/shared";
+import StatusPill from "../../../components/StatusPill.js";
 
 const SLOT_LABELS: Record<string, string> = {
   morning: "Morning",
@@ -58,9 +59,9 @@ export default function RoutineCard({ routine, showSlotBadge }: Props) {
         </div>
       </div>
 
-      <span className="shrink-0 rounded-full border-[1.5px] border-[var(--color-amber-100)] bg-[var(--color-amber-50)] px-3 py-1 font-display text-sm font-bold text-[var(--color-amber-700)]">
+      <StatusPill hasBorder className="shrink-0">
         {routine.points} {routine.points === 1 ? "pt" : "pts"}
-      </span>
+      </StatusPill>
     </Link>
   );
 }

--- a/packages/client/src/features/child/routines/RoutineChecklist.tsx
+++ b/packages/client/src/features/child/routines/RoutineChecklist.tsx
@@ -6,6 +6,7 @@ import { useChecklist } from "./hooks/useChecklist.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
 import { saveDraft, deleteDraft } from "../../../lib/draft.js";
 import ChecklistItem from "./ChecklistItem.js";
+import StatusPill from "../../../components/StatusPill.js";
 
 const NAVIGATION_DELAY_MS = 1500;
 
@@ -169,9 +170,9 @@ export default function RoutineChecklist() {
             <h1 className="font-display text-xl font-bold text-[var(--color-text)]">{routine.name}</h1>
           </div>
 
-          <span className="rounded-full bg-[var(--color-amber-100)] px-3 py-1 text-sm font-bold text-[var(--color-amber-700)]">
+          <StatusPill>
             {routine.points} {routine.points === 1 ? "pt" : "pts"}
-          </span>
+          </StatusPill>
         </div>
 
         <div className="mt-2 flex items-center justify-between">

--- a/packages/client/src/features/child/today/TodayScreen.tsx
+++ b/packages/client/src/features/child/today/TodayScreen.tsx
@@ -7,6 +7,7 @@ import PointsBadge from "./PointsBadge.js";
 import Mascot from "../../../components/mascot/Mascot.js";
 import { determineMascotState, isRecentApproval } from "../../../components/mascot/mascotStates.js";
 import { hasAnyActiveDraft } from "../../../lib/draft.js";
+import StatusPill from "../../../components/StatusPill.js";
 
 function getGreeting(): string {
   const hour = new Date().getHours();
@@ -116,9 +117,9 @@ export default function TodayScreen() {
           <div className="mt-5 flex items-center gap-2">
             <h2 className="font-display text-lg font-semibold text-[var(--color-text-secondary)]">Your Routines</h2>
             {pendingCount > 0 && (
-              <span className="rounded-full bg-[var(--color-amber-100)] px-2.5 py-0.5 text-[11px] font-bold text-[var(--color-amber-700)]">
+              <StatusPill size="sm">
                 {pendingCount} pending
-              </span>
+              </StatusPill>
             )}
           </div>
 
@@ -134,9 +135,9 @@ export default function TodayScreen() {
         <div className="flex items-center gap-2">
           <h2 className="font-display text-lg font-semibold text-[var(--color-text-secondary)]">Chores</h2>
           {pendingChoreCount > 0 && (
-            <span className="rounded-full bg-[var(--color-amber-100)] px-2.5 py-0.5 text-[11px] font-bold text-[var(--color-amber-700)]">
+            <StatusPill size="sm">
               {pendingChoreCount} pending
-            </span>
+            </StatusPill>
           )}
         </div>
         <div className="mt-3">

--- a/packages/client/tests/components/StatusPill.test.tsx
+++ b/packages/client/tests/components/StatusPill.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import StatusPill from "../../src/components/StatusPill.js";
+
+describe("StatusPill", () => {
+  it("renders children text", () => {
+    render(<StatusPill>3 pending</StatusPill>);
+
+    expect(screen.getByText("3 pending")).toBeInTheDocument();
+  });
+
+  it("renders as a span element", () => {
+    render(<StatusPill>badge</StatusPill>);
+
+    const el = screen.getByText("badge");
+    expect(el.tagName).toBe("SPAN");
+  });
+
+  it("applies medium size classes by default", () => {
+    render(<StatusPill>5 pts</StatusPill>);
+
+    const el = screen.getByText("5 pts");
+    expect(el.className).toContain("px-3");
+    expect(el.className).toContain("py-1");
+    expect(el.className).toContain("text-sm");
+    expect(el.className).toContain("font-display");
+  });
+
+  it("applies small size classes when size is sm", () => {
+    render(<StatusPill size="sm">2 pending</StatusPill>);
+
+    const el = screen.getByText("2 pending");
+    expect(el.className).toContain("px-2.5");
+    expect(el.className).toContain("py-0.5");
+    expect(el.className).toContain("text-[11px]");
+  });
+
+  it("does not apply border by default", () => {
+    render(<StatusPill>no border</StatusPill>);
+
+    const el = screen.getByText("no border");
+    expect(el.className).toContain("bg-[var(--color-amber-100)]");
+    expect(el.className).not.toContain("border");
+  });
+
+  it("applies border classes when hasBorder is true", () => {
+    render(<StatusPill hasBorder>bordered</StatusPill>);
+
+    const el = screen.getByText("bordered");
+    expect(el.className).toContain("border");
+    expect(el.className).toContain("border-[var(--color-amber-100)]");
+    expect(el.className).toContain("bg-[var(--color-amber-50)]");
+  });
+
+  it("always applies rounded-full and amber text color", () => {
+    render(<StatusPill>styled</StatusPill>);
+
+    const el = screen.getByText("styled");
+    expect(el.className).toContain("rounded-full");
+    expect(el.className).toContain("text-[var(--color-amber-700)]");
+  });
+
+  it("appends custom className", () => {
+    render(<StatusPill className="shrink-0">custom</StatusPill>);
+
+    const el = screen.getByText("custom");
+    expect(el.className).toContain("shrink-0");
+  });
+
+  it("renders number children", () => {
+    render(<StatusPill>{42}</StatusPill>);
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders JSX children", () => {
+    render(
+      <StatusPill>
+        <span data-testid="inner">nested</span>
+      </StatusPill>,
+    );
+
+    expect(screen.getByTestId("inner")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

The amber pill styling pattern (rounded-full, amber background/text, font-display bold) was duplicated across 5 components with minor variations. Each instance repeated the same long className string, making the styling inconsistent and harder to maintain.

## What this PR does

Extracts a shared `<StatusPill>` component in `packages/client/src/components/StatusPill.tsx` that encapsulates the common amber pill styling. The component accepts:

- `size` prop (`"sm"` | `"md"`) — `sm` for count badges (11px text, compact padding), `md` for points displays (14px text, `font-display`)
- `hasBorder` prop — adds a 1px amber border with lighter amber-50 background (used for standalone points pills)
- `className` prop — allows consumers to add layout classes like `shrink-0`

Replaces inline amber pill classNames in:
- `TodayScreen.tsx` — pending routine and chore count badges (x2, `size="sm"`)
- `RoutineCard.tsx` — points display pill (`hasBorder`, `className="shrink-0"`)
- `RoutineChecklist.tsx` — points display pill (default `md`)
- `RewardCard.tsx` — "Pending" status badge (`size="sm"`)
- `QuickChoreLog.tsx` — tier points pill (default `md`)

`PointsBadge.tsx` was intentionally left unchanged — it renders a `<button>` with interactive states (`active:scale-95`, `shadow-sm`, navigation on click), making it semantically different from a static `<span>` pill.

## Test plan

1. Open the Today screen with pending routines and chores. Verify that the amber "N pending" badges next to "Your Routines" and "Chores" headings render correctly with rounded-full amber styling.
2. Verify that routine cards show their points pill (e.g., "5 pts") with a bordered amber style on the right side.
3. Navigate into a routine checklist. Verify that the points pill in the header renders correctly.
4. Request a reward, then view the rewards list. Verify that the "Pending" badge on the reward card renders with amber styling.
5. Open the chore log and select a chore. Verify that tier points pills (e.g., "+5 pts") render correctly.
6. Run `npm run test -- --run` and verify all 988 tests pass, including the 10 new StatusPill tests.

Closes #64