### PR TITLE
Add image deletion to admin asset management

### DIFF
--- a/packages/client/src/features/admin/assets/AssetPicker.tsx
+++ b/packages/client/src/features/admin/assets/AssetPicker.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useId } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useState, useRef, useId, useEffect } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, notifyAdminAuthError } from "../../../api/client.js";
 import { queryKeys } from "../../../lib/query-keys.js";
 import { IMAGE_MODELS, DEFAULT_IMAGE_MODEL } from "@chore-app/shared";
-import type { Asset, ImageModelId } from "@chore-app/shared";
+import type { Asset, AssetUsage, ImageModelId } from "@chore-app/shared";
 
 export interface AssetPickerProps {
   value: number | null;
@@ -106,9 +106,12 @@ export default function AssetPicker({ value, imageUrl, onChange, label }: AssetP
   const [generatePrompt, setGeneratePrompt] = useState("");
   const [selectedModel, setSelectedModel] = useState<ImageModelId>(DEFAULT_IMAGE_MODEL);
   const [error, setError] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Asset | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const deleteDialogRef = useRef<HTMLDivElement>(null);
   const promptId = useId();
   const modelId = useId();
+  const queryClient = useQueryClient();
 
   const { data: assets, isLoading: isLoadingAssets } = useQuery({
     queryKey: queryKeys.admin.assets({ status: "active" }),
@@ -119,6 +122,38 @@ export default function AssetPicker({ value, imageUrl, onChange, label }: AssetP
     },
     enabled: mode === "browse",
   });
+
+  const { data: deleteTargetUsage, isLoading: isLoadingUsage } = useQuery({
+    queryKey: ["admin", "assets", deleteTarget?.id, "usage"],
+    queryFn: async () => {
+      const result = await api.get<AssetUsage>(`/api/admin/assets/${deleteTarget!.id}/usage`);
+      if (!result.ok) throw result.error;
+      return result.data;
+    },
+    enabled: deleteTarget !== null,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (assetId: number) => {
+      const result = await api.delete<{ success: boolean }>(`/api/admin/assets/${assetId}`);
+      if (!result.ok) throw new Error(result.error.message);
+      return result.data;
+    },
+    onSuccess: (_data, deletedAssetId) => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "assets"] });
+      if (value === deletedAssetId) {
+        onChange(null, null);
+      }
+      setDeleteTarget(null);
+    },
+  });
+
+  useEffect(() => {
+    if (deleteTarget && deleteDialogRef.current) {
+      const firstButton = deleteDialogRef.current.querySelector<HTMLButtonElement>("button");
+      firstButton?.focus();
+    }
+  }, [deleteTarget, isLoadingUsage]);
 
   function handleClear() {
     onChange(null, null);
@@ -268,30 +303,92 @@ export default function AssetPicker({ value, imageUrl, onChange, label }: AssetP
           ) : assets && assets.length > 0 ? (
             <div className="mt-3 grid grid-cols-4 gap-2 tablet:grid-cols-6" role="listbox" aria-label="Available assets">
               {assets.map((asset) => (
-                <button
-                  key={asset.id}
-                  type="button"
-                  role="option"
-                  aria-selected={asset.id === value}
-                  onClick={() => handleSelectAsset(asset)}
-                  className={`overflow-hidden rounded-xl border-2 transition-all hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-amber-500)] ${
-                    asset.id === value
-                      ? "border-[var(--color-amber-500)]"
-                      : "border-[var(--color-border)]"
-                  }`}
-                >
-                  <img
-                    src={asset.url}
-                    alt={asset.originalFilename ?? `Asset ${asset.id}`}
-                    className="aspect-square w-full object-cover"
-                  />
-                </button>
+                <div key={asset.id} className="relative">
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={asset.id === value}
+                    onClick={() => handleSelectAsset(asset)}
+                    className={`w-full overflow-hidden rounded-xl border-2 transition-all hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-amber-500)] ${
+                      asset.id === value
+                        ? "border-[var(--color-amber-500)]"
+                        : "border-[var(--color-border)]"
+                    }`}
+                  >
+                    <img
+                      src={asset.url}
+                      alt={asset.originalFilename ?? `Asset ${asset.id}`}
+                      className="aspect-square w-full object-cover"
+                    />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteTarget(asset);
+                      setError(null);
+                    }}
+                    aria-label={`Delete ${asset.originalFilename ?? `Asset ${asset.id}`}`}
+                    className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--color-red-600)] text-white shadow-card transition-colors hover:opacity-80"
+                  >
+                    <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3} aria-hidden="true">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                  </button>
+                </div>
               ))}
             </div>
           ) : (
             <p className="mt-3 text-center text-sm text-[var(--color-text-muted)]">
               No assets available.
             </p>
+          )}
+
+          {deleteTarget && (
+            <div ref={deleteDialogRef} className="mt-3 rounded-xl border border-[var(--color-red-600)] bg-[var(--color-surface)] p-3" role="alertdialog" aria-label="Confirm asset deletion">
+              {isLoadingUsage ? (
+                <p className="text-sm text-[var(--color-text-secondary)]">Checking usage...</p>
+              ) : (
+                <>
+                  <p className="text-sm font-medium text-[var(--color-text-secondary)]">
+                    Delete this image permanently?
+                  </p>
+                  {deleteTargetUsage && deleteTargetUsage.usedBy.length > 0 && (
+                    <p className="mt-1 text-sm text-[var(--color-red-600)]">
+                      This image is used by{" "}
+                      {deleteTargetUsage.usedBy.map((u) => u.entityName).join(" and ")}
+                      . Removing it will clear the image from{" "}
+                      {deleteTargetUsage.usedBy.length === 1 ? "that item" : "those items"}.
+                    </p>
+                  )}
+                  <div className="mt-3 flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setDeleteTarget(null);
+                        deleteMutation.reset();
+                      }}
+                      className="min-h-touch flex-1 rounded-xl px-4 py-2 text-sm font-display font-bold text-[var(--color-text-muted)] hover:bg-[var(--color-surface-muted)]"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => deleteMutation.mutate(deleteTarget.id)}
+                      disabled={deleteMutation.isPending}
+                      className="min-h-touch flex-1 rounded-xl bg-[var(--color-red-600)] px-4 py-2 text-sm font-display font-bold text-white hover:opacity-80 disabled:opacity-50"
+                    >
+                      {deleteMutation.isPending ? "Deleting..." : "Delete"}
+                    </button>
+                  </div>
+                  {deleteMutation.isError && (
+                    <p className="mt-2 text-sm text-[var(--color-red-600)]" role="alert" aria-live="assertive">
+                      {deleteMutation.error instanceof Error ? deleteMutation.error.message : "Delete failed"}
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
           )}
         </div>
       )}

--- a/packages/client/tests/features/admin/assets/AssetPicker.test.tsx
+++ b/packages/client/tests/features/admin/assets/AssetPicker.test.tsx
@@ -306,6 +306,228 @@ describe("AssetPicker", () => {
     expect(getGenerateSubmitButton()).toBeDisabled();
   });
 
+  it("shows delete button on each asset in browse mode", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    expect(screen.getByRole("button", { name: "Delete photo.jpg" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete Asset 2" })).toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog when delete button is clicked", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({ data: { assetId: 1, usedBy: [] } }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete this image permanently?")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("shows usage warning when asset is linked to entities", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({
+          data: {
+            assetId: 1,
+            usedBy: [
+              { entityType: "routine", entityId: 1, entityName: "Morning Routine" },
+              { entityType: "reward", entityId: 2, entityName: "Ice Cream" },
+            ],
+          },
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Morning Routine and Ice Cream/u)).toBeInTheDocument();
+      expect(screen.getByText(/clear the image from those items/u)).toBeInTheDocument();
+    });
+  });
+
+  it("deletes asset and refreshes gallery on confirm", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({ data: { assetId: 1, usedBy: [] } }),
+      ),
+      http.delete("/api/admin/assets/1", () =>
+        HttpResponse.json({ data: { success: true } }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete this image permanently?")).not.toBeInTheDocument();
+    });
+  });
+
+  it("cancels deletion when cancel is clicked", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({ data: { assetId: 1, usedBy: [] } }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete this image permanently?")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByText("Delete this image permanently?")).not.toBeInTheDocument();
+  });
+
+  it("calls onChange with null when the currently-selected asset is deleted", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({ data: { assetId: 1, usedBy: [] } }),
+      ),
+      http.delete("/api/admin/assets/1", () =>
+        HttpResponse.json({ data: { success: true } }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    const { onChange } = renderAssetPicker({ value: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(null, null);
+    });
+  });
+
+  it("shows error when delete request fails", async () => {
+    server.use(
+      http.get("/api/admin/assets", () =>
+        HttpResponse.json({ data: mockAssets }),
+      ),
+      http.get("/api/admin/assets/1/usage", () =>
+        HttpResponse.json({ data: { assetId: 1, usedBy: [] } }),
+      ),
+      http.delete("/api/admin/assets/1", () =>
+        HttpResponse.json(
+          { error: { code: "SERVER_ERROR", message: "Delete failed" } },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderAssetPicker();
+
+    await user.click(screen.getByRole("button", { name: "Browse" }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole("option")).toHaveLength(2);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete photo.jpg" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Delete failed");
+    });
+  });
+
   it("shows loading state in asset library", async () => {
     server.use(
       http.get("/api/admin/assets", async () => {

--- a/packages/server/src/routes/admin-assets.ts
+++ b/packages/server/src/routes/admin-assets.ts
@@ -69,6 +69,43 @@ export function createAdminAssetsRoutes(
     }
   });
 
+  router.get("/assets/:id/usage", (req, res, next) => {
+    try {
+      const idParam = req.params.id;
+      if (!/^\d+$/u.test(idParam)) {
+        throw new ValidationError("Invalid asset ID");
+      }
+
+      const usage = assetService.getAssetUsage(Number(idParam));
+      res.json({
+        data: {
+          assetId: Number(idParam),
+          usedBy: usage.map((u) => ({
+            entityType: u.entity_type,
+            entityId: u.entity_id,
+            entityName: u.entity_name,
+          })),
+        },
+      });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete("/assets/:id", (req, res, next) => {
+    try {
+      const idParam = req.params.id;
+      if (!/^\d+$/u.test(idParam)) {
+        throw new ValidationError("Invalid asset ID");
+      }
+
+      assetService.deleteAsset(Number(idParam));
+      res.json({ data: { success: true } });
+    } catch (err) {
+      next(err);
+    }
+  });
+
   router.post("/assets/generate", async (req, res, next) => {
     try {
       const { prompt, model } = req.body;

--- a/packages/server/src/services/assetService.ts
+++ b/packages/server/src/services/assetService.ts
@@ -62,11 +62,19 @@ export interface UploadFile {
   size: number;
 }
 
+export interface AssetUsageRow {
+  entity_type: string;
+  entity_id: number;
+  entity_name: string;
+}
+
 export interface AssetService {
   processUpload(file: UploadFile): Promise<Asset>;
   generateImage(prompt: string, model: string | undefined, apiKey: string): Promise<Asset>;
   getAssets(filters?: AssetFilters): Asset[];
   archiveAsset(id: number): void;
+  getAssetUsage(id: number): AssetUsageRow[];
+  deleteAsset(id: number): void;
 }
 
 function detectMimeType(buffer: Buffer): string | null {
@@ -283,6 +291,19 @@ export function createAssetService(
 
   const selectByIdStmt = db.prepare(`SELECT * FROM assets WHERE id = ?`);
 
+  const selectUsageStmt = db.prepare(`
+    SELECT 'routine' AS entity_type, id AS entity_id, name AS entity_name FROM routines WHERE image_asset_id = ?
+    UNION ALL
+    SELECT 'checklist_item' AS entity_type, ci.id AS entity_id, ci.label AS entity_name FROM checklist_items ci WHERE ci.image_asset_id = ?
+    UNION ALL
+    SELECT 'reward' AS entity_type, id AS entity_id, name AS entity_name FROM rewards WHERE image_asset_id = ?
+  `);
+
+  const clearRoutineAssetStmt = db.prepare(`UPDATE routines SET image_asset_id = NULL WHERE image_asset_id = ?`);
+  const clearChecklistItemAssetStmt = db.prepare(`UPDATE checklist_items SET image_asset_id = NULL WHERE image_asset_id = ?`);
+  const clearRewardAssetStmt = db.prepare(`UPDATE rewards SET image_asset_id = NULL WHERE image_asset_id = ?`);
+  const deleteAssetStmt = db.prepare(`DELETE FROM assets WHERE id = ?`);
+
   async function processUpload(file: UploadFile): Promise<Asset> {
     const assetsDir = path.join(dataDir, "assets");
     fs.mkdirSync(assetsDir, { recursive: true });
@@ -437,5 +458,47 @@ export function createAssetService(
     });
   }
 
-  return { processUpload, generateImage, getAssets, archiveAsset };
+  function getAssetUsage(id: number): AssetUsageRow[] {
+    const asset = selectByIdStmt.get(id) as AssetRow | undefined;
+    if (!asset) {
+      throw new NotFoundError("Asset not found");
+    }
+    return selectUsageStmt.all(id, id, id) as AssetUsageRow[];
+  }
+
+  const deleteAssetTransaction = db.transaction((id: number) => {
+    const asset = selectByIdStmt.get(id) as AssetRow | undefined;
+    if (!asset) {
+      throw new NotFoundError("Asset not found");
+    }
+
+    clearRoutineAssetStmt.run(id);
+    clearChecklistItemAssetStmt.run(id);
+    clearRewardAssetStmt.run(id);
+    deleteAssetStmt.run(id);
+
+    if (asset.stored_filename) {
+      const filePath = path.join(dataDir, "assets", asset.stored_filename);
+      try {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+      } catch {
+        // File cleanup is best-effort; the DB record is already gone
+      }
+    }
+
+    activityService.recordActivity({
+      eventType: "asset_deleted",
+      entityType: "asset",
+      entityId: id,
+      summary: `Deleted asset: ${asset.stored_filename}`,
+    });
+  });
+
+  function deleteAsset(id: number): void {
+    deleteAssetTransaction(id);
+  }
+
+  return { processUpload, generateImage, getAssets, archiveAsset, getAssetUsage, deleteAsset };
 }

--- a/packages/server/tests/routes/assets.test.ts
+++ b/packages/server/tests/routes/assets.test.ts
@@ -199,6 +199,144 @@ describe("assets routes", () => {
     });
   });
 
+  describe("GET /api/admin/assets/:id/usage", () => {
+    it("returns empty usage for an unused asset", async () => {
+      const uploadRes = await request(app)
+        .post("/api/admin/assets/upload")
+        .set("Cookie", cookies)
+        .attach("file", fixtures.validJpgPath, {
+          filename: "unused.jpg",
+          contentType: "image/jpeg",
+        });
+
+      const assetId = uploadRes.body.data.id;
+
+      const res = await request(app)
+        .get(`/api/admin/assets/${assetId}/usage`)
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.assetId).toBe(assetId);
+      expect(res.body.data.usedBy).toHaveLength(0);
+    });
+
+    it("returns usage when asset is linked to a routine", async () => {
+      const uploadRes = await request(app)
+        .post("/api/admin/assets/upload")
+        .set("Cookie", cookies)
+        .attach("file", fixtures.validJpgPath, {
+          filename: "routine-linked.jpg",
+          contentType: "image/jpeg",
+        });
+
+      const assetId = uploadRes.body.data.id;
+
+      db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule, image_asset_id) VALUES (?, ?, ?, ?)`
+      ).run("Test Routine", "morning", "once_per_day", assetId);
+
+      const res = await request(app)
+        .get(`/api/admin/assets/${assetId}/usage`)
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.usedBy).toHaveLength(1);
+      expect(res.body.data.usedBy[0].entityType).toBe("routine");
+      expect(res.body.data.usedBy[0].entityName).toBe("Test Routine");
+    });
+
+    it("returns 401 without admin session", async () => {
+      const res = await request(app).get("/api/admin/assets/1/usage");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 for nonexistent asset", async () => {
+      const res = await request(app)
+        .get("/api/admin/assets/9999/usage")
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 422 for invalid asset ID", async () => {
+      const res = await request(app)
+        .get("/api/admin/assets/abc/usage")
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(422);
+    });
+  });
+
+  describe("DELETE /api/admin/assets/:id", () => {
+    it("deletes the asset and returns success", async () => {
+      const uploadRes = await request(app)
+        .post("/api/admin/assets/upload")
+        .set("Cookie", cookies)
+        .attach("file", fixtures.validJpgPath, {
+          filename: "to-delete.jpg",
+          contentType: "image/jpeg",
+        });
+
+      const assetId = uploadRes.body.data.id;
+
+      const deleteRes = await request(app)
+        .delete(`/api/admin/assets/${assetId}`)
+        .set("Cookie", cookies);
+
+      expect(deleteRes.status).toBe(200);
+      expect(deleteRes.body.data.success).toBe(true);
+
+      const listRes = await request(app)
+        .get("/api/admin/assets")
+        .set("Cookie", cookies);
+      expect(listRes.body.data.find((a: { id: number }) => a.id === assetId)).toBeUndefined();
+    });
+
+    it("clears image from linked entities on delete", async () => {
+      const uploadRes = await request(app)
+        .post("/api/admin/assets/upload")
+        .set("Cookie", cookies)
+        .attach("file", fixtures.validJpgPath, {
+          filename: "linked-delete.jpg",
+          contentType: "image/jpeg",
+        });
+
+      const assetId = uploadRes.body.data.id;
+
+      db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule, image_asset_id) VALUES (?, ?, ?, ?)`
+      ).run("Linked Routine", "morning", "once_per_day", assetId);
+
+      await request(app)
+        .delete(`/api/admin/assets/${assetId}`)
+        .set("Cookie", cookies);
+
+      const routine = db.prepare(`SELECT image_asset_id FROM routines WHERE name = ?`).get("Linked Routine") as { image_asset_id: number | null };
+      expect(routine.image_asset_id).toBeNull();
+    });
+
+    it("returns 401 without admin session", async () => {
+      const res = await request(app).delete("/api/admin/assets/1");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 for nonexistent asset", async () => {
+      const res = await request(app)
+        .delete("/api/admin/assets/9999")
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 422 for invalid asset ID", async () => {
+      const res = await request(app)
+        .delete("/api/admin/assets/abc")
+        .set("Cookie", cookies);
+
+      expect(res.status).toBe(422);
+    });
+  });
+
   describe("POST /api/admin/assets/generate", () => {
     it("returns 503 when image generation is not configured", async () => {
       const res = await request(app)

--- a/packages/server/tests/services/assetService.test.ts
+++ b/packages/server/tests/services/assetService.test.ts
@@ -326,6 +326,187 @@ describe("assetService", () => {
     });
   });
 
+  describe("getAssetUsage", () => {
+    async function seedUploadForUsage(service: ReturnType<typeof buildService>, name: string) {
+      const tmpPath = copyToTemp(fixtures.validJpgPath, dataDir, `usage-${Date.now()}-${name}`);
+      const stat = fs.statSync(tmpPath);
+      return service.processUpload({
+        path: tmpPath,
+        originalname: name,
+        size: stat.size,
+      });
+    }
+
+    it("returns empty array when asset is not used by any entity", async () => {
+      const service = buildService();
+      const asset = await seedUploadForUsage(service, "unused.jpg");
+
+      const usage = service.getAssetUsage(asset.id);
+      expect(usage).toHaveLength(0);
+    });
+
+    it("returns routine usage when asset is assigned to a routine", async () => {
+      const service = buildService();
+      const asset = await seedUploadForUsage(service, "routine-img.jpg");
+
+      db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule, image_asset_id) VALUES (?, ?, ?, ?)`
+      ).run("Morning Routine", "morning", "once_per_day", asset.id);
+
+      const usage = service.getAssetUsage(asset.id);
+      expect(usage).toHaveLength(1);
+      expect(usage[0].entity_type).toBe("routine");
+      expect(usage[0].entity_name).toBe("Morning Routine");
+    });
+
+    it("returns reward usage when asset is assigned to a reward", async () => {
+      const service = buildService();
+      const asset = await seedUploadForUsage(service, "reward-img.jpg");
+
+      db.prepare(
+        `INSERT INTO rewards (name, points_cost, image_asset_id) VALUES (?, ?, ?)`
+      ).run("Ice Cream", 50, asset.id);
+
+      const usage = service.getAssetUsage(asset.id);
+      expect(usage).toHaveLength(1);
+      expect(usage[0].entity_type).toBe("reward");
+      expect(usage[0].entity_name).toBe("Ice Cream");
+    });
+
+    it("returns checklist item usage when asset is assigned to a checklist item", async () => {
+      const service = buildService();
+      const asset = await seedUploadForUsage(service, "checklist-img.jpg");
+
+      const routineResult = db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule) VALUES (?, ?, ?)`
+      ).run("Test Routine", "morning", "once_per_day");
+
+      db.prepare(
+        `INSERT INTO checklist_items (routine_id, label, image_asset_id) VALUES (?, ?, ?)`
+      ).run(routineResult.lastInsertRowid, "Brush Teeth", asset.id);
+
+      const usage = service.getAssetUsage(asset.id);
+      expect(usage).toHaveLength(1);
+      expect(usage[0].entity_type).toBe("checklist_item");
+      expect(usage[0].entity_name).toBe("Brush Teeth");
+    });
+
+    it("returns multiple usage entries across entity types", async () => {
+      const service = buildService();
+      const asset = await seedUploadForUsage(service, "shared-img.jpg");
+
+      db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule, image_asset_id) VALUES (?, ?, ?, ?)`
+      ).run("Morning Routine", "morning", "once_per_day", asset.id);
+      db.prepare(
+        `INSERT INTO rewards (name, points_cost, image_asset_id) VALUES (?, ?, ?)`
+      ).run("Pizza Night", 100, asset.id);
+
+      const usage = service.getAssetUsage(asset.id);
+      expect(usage).toHaveLength(2);
+    });
+
+    it("throws NotFoundError for nonexistent asset", () => {
+      const service = buildService();
+      expect(() => service.getAssetUsage(9999)).toThrow(NotFoundError);
+    });
+  });
+
+  describe("deleteAsset", () => {
+    async function seedUploadForDelete(service: ReturnType<typeof buildService>, name: string) {
+      const tmpPath = copyToTemp(fixtures.validJpgPath, dataDir, `del-${Date.now()}-${name}`);
+      const stat = fs.statSync(tmpPath);
+      return service.processUpload({
+        path: tmpPath,
+        originalname: name,
+        size: stat.size,
+      });
+    }
+
+    it("deletes asset record from database", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "to-delete.jpg");
+
+      service.deleteAsset(asset.id);
+
+      const assets = service.getAssets();
+      expect(assets.find((a) => a.id === asset.id)).toBeUndefined();
+    });
+
+    it("removes the file from disk", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "disk-delete.jpg");
+
+      const filePath = path.join(dataDir, "assets", asset.storedFilename!);
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      service.deleteAsset(asset.id);
+      expect(fs.existsSync(filePath)).toBe(false);
+    });
+
+    it("clears image_asset_id from linked routines", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "routine-clear.jpg");
+
+      db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule, image_asset_id) VALUES (?, ?, ?, ?)`
+      ).run("Morning Routine", "morning", "once_per_day", asset.id);
+
+      service.deleteAsset(asset.id);
+
+      const routine = db.prepare(`SELECT image_asset_id FROM routines WHERE name = ?`).get("Morning Routine") as { image_asset_id: number | null };
+      expect(routine.image_asset_id).toBeNull();
+    });
+
+    it("clears image_asset_id from linked rewards", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "reward-clear.jpg");
+
+      db.prepare(
+        `INSERT INTO rewards (name, points_cost, image_asset_id) VALUES (?, ?, ?)`
+      ).run("Ice Cream", 50, asset.id);
+
+      service.deleteAsset(asset.id);
+
+      const reward = db.prepare(`SELECT image_asset_id FROM rewards WHERE name = ?`).get("Ice Cream") as { image_asset_id: number | null };
+      expect(reward.image_asset_id).toBeNull();
+    });
+
+    it("clears image_asset_id from linked checklist items", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "checklist-clear.jpg");
+
+      const routineResult = db.prepare(
+        `INSERT INTO routines (name, time_slot, completion_rule) VALUES (?, ?, ?)`
+      ).run("Test Routine", "morning", "once_per_day");
+
+      db.prepare(
+        `INSERT INTO checklist_items (routine_id, label, image_asset_id) VALUES (?, ?, ?)`
+      ).run(routineResult.lastInsertRowid, "Brush Teeth", asset.id);
+
+      service.deleteAsset(asset.id);
+
+      const item = db.prepare(`SELECT image_asset_id FROM checklist_items WHERE label = ?`).get("Brush Teeth") as { image_asset_id: number | null };
+      expect(item.image_asset_id).toBeNull();
+    });
+
+    it("throws NotFoundError for nonexistent asset", () => {
+      const service = buildService();
+      expect(() => service.deleteAsset(9999)).toThrow(NotFoundError);
+    });
+
+    it("records activity event on deletion", async () => {
+      const service = buildService();
+      const asset = await seedUploadForDelete(service, "activity-test.jpg");
+
+      service.deleteAsset(asset.id);
+
+      const event = db.prepare(`SELECT * FROM activity_events WHERE event_type = 'asset_deleted' AND entity_id = ?`).get(asset.id) as { summary: string } | undefined;
+      expect(event).toBeDefined();
+      expect(event!.summary).toContain("Deleted asset");
+    });
+  });
+
   describe("generateImage", () => {
     let validPngBuffer: Buffer;
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -52,6 +52,7 @@ export const ACTIVITY_EVENT_TYPES = [
   "asset_uploaded",
   "asset_generated",
   "asset_archived",
+  "asset_deleted",
   "backup_exported",
   "backup_restored",
 ] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,6 +31,8 @@ export type {
   PendingApprovals,
   BackupManifest,
   Asset,
+  AssetUsage,
+  AssetUsageItem,
   PushSubscribePayload,
 } from "./types.js";
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -230,6 +230,17 @@ export interface Asset {
   url: string;
 }
 
+export interface AssetUsageItem {
+  entityType: "routine" | "checklist_item" | "reward";
+  entityId: number;
+  entityName: string;
+}
+
+export interface AssetUsage {
+  assetId: number;
+  usedBy: AssetUsageItem[];
+}
+
 export interface TodayPointActivity {
   id: number;
   entryType: EntryType;


### PR DESCRIPTION
## Summary

There's no way to delete images from the asset gallery. Bad generations and unwanted uploads stay forever, bloating the file system and cluttering the gallery. This adds a delete flow with confirmation and usage warnings so admins can clean up assets safely.

- Add `DELETE /api/admin/assets/:id` endpoint that cascade-clears `image_asset_id` from routines, checklist items, and rewards, deletes the DB record, and removes the file from disk -- all in a single `db.transaction()`
- Add `GET /api/admin/assets/:id/usage` endpoint that returns which entities reference the asset (via `selectUsageStmt` UNION ALL across routines, checklist_items, rewards)
- Add `deleteAsset()` and `getAssetUsage()` methods to `AssetService` interface and implementation
- Add `AssetUsage` and `AssetUsageItem` types to shared package
- Add `asset_deleted` activity event type to `ACTIVITY_EVENT_TYPES`
- Add delete button (red X badge) on each asset thumbnail in the AssetPicker browse gallery
- Show confirmation dialog with usage warnings before deletion (e.g., "This image is used by Morning Routine and Ice Cream. Removing it will clear the image from those items.")
- If the currently-selected asset is deleted, call `onChange(null, null)` to clear the parent form's reference
- Invalidate asset query cache after successful deletion to refresh the gallery

## Test plan

### Server tests (service + routes)

1. `getAssetUsage` -- returns empty array for unused asset
2. `getAssetUsage` -- returns routine, reward, and checklist item usage
3. `getAssetUsage` -- returns multiple entries across entity types
4. `getAssetUsage` -- throws `NotFoundError` for nonexistent asset
5. `deleteAsset` -- removes asset record from DB
6. `deleteAsset` -- deletes file from disk
7. `deleteAsset` -- clears `image_asset_id` from linked routines, rewards, and checklist items
8. `deleteAsset` -- throws `NotFoundError` for nonexistent asset
9. `deleteAsset` -- records `asset_deleted` activity event
10. `DELETE /api/admin/assets/:id` -- returns 200 with `{ success: true }`
11. `DELETE /api/admin/assets/:id` -- clears linked entity references
12. `DELETE /api/admin/assets/:id` -- returns 401 without admin session
13. `DELETE /api/admin/assets/:id` -- returns 404 for nonexistent asset
14. `DELETE /api/admin/assets/:id` -- returns 422 for invalid ID
15. `GET /api/admin/assets/:id/usage` -- returns empty usage, linked usage, 401/404/422

### Client tests (AssetPicker)

1. Verify that delete buttons appear on each asset in browse mode
2. Verify that clicking delete shows the confirmation dialog with Cancel and Delete buttons
3. Verify that usage warnings appear when the asset is linked to entities
4. Verify that confirming delete dismisses the dialog
5. Verify that canceling dismisses the dialog without deleting
6. Verify that `onChange(null, null)` is called when the currently-selected asset is deleted
7. Verify that an error message appears when the delete API call fails

Closes #95