### PR TITLE
Add auto-dismiss and Log Another button to chore confirmation

### DIFF
--- a/packages/client/src/features/child/chores/QuickChoreLog.tsx
+++ b/packages/client/src/features/child/chores/QuickChoreLog.tsx
@@ -35,18 +35,27 @@ export default function QuickChoreLog() {
     }
   }, [polledLog, queryClient]);
 
-  const recentLogId = recentLog?.id;
-  const recentLogStatus = recentLog?.status;
-  const isCancelPending = cancelMutation.isPending;
-  useEffect(() => {
+  function scheduleAutoDismiss() {
     clearTimeout(autoDismissRef.current);
-    if (!recentLogId || recentLogStatus === "pending" || isCancelPending) return;
-
     autoDismissRef.current = setTimeout(() => {
       if (!isPausedRef.current) {
         setRecentLog(null);
       }
     }, AUTO_DISMISS_DELAY_MS);
+  }
+
+  const recentLogId = recentLog?.id;
+  const recentLogStatus = recentLog?.status;
+  const isCancelPending = cancelMutation.isPending;
+  useEffect(() => {
+    clearTimeout(autoDismissRef.current);
+    if (!recentLogId) {
+      isPausedRef.current = false;
+      return;
+    }
+    if (recentLogStatus === "pending" || isCancelPending) return;
+
+    scheduleAutoDismiss();
 
     return () => clearTimeout(autoDismissRef.current);
   }, [recentLogId, recentLogStatus, isCancelPending]);
@@ -59,11 +68,7 @@ export default function QuickChoreLog() {
   function handleConfirmationBlur() {
     isPausedRef.current = false;
     if (recentLog && recentLog.status !== "pending" && !cancelMutation.isPending) {
-      autoDismissRef.current = setTimeout(() => {
-        if (!isPausedRef.current) {
-          setRecentLog(null);
-        }
-      }, AUTO_DISMISS_DELAY_MS);
+      scheduleAutoDismiss();
     }
   }
 

--- a/packages/client/tests/features/child/chores/QuickChoreLog.test.tsx
+++ b/packages/client/tests/features/child/chores/QuickChoreLog.test.tsx
@@ -390,6 +390,50 @@ describe('QuickChoreLog', () => {
       expect(screen.queryByText(/clean kitchen approved/i)).not.toBeInTheDocument();
       expect(screen.getByText('Pick a Chore')).toBeInTheDocument();
     });
+
+    it('resumes auto-dismiss for next confirmation after dismissing a focused card', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+      renderWithProviders(<QuickChoreLog />);
+
+      await user.click(screen.getByRole('button', { name: /log a chore/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Clean Kitchen')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('Clean Kitchen'));
+      await user.click(screen.getByText('Quick Clean'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/clean kitchen approved/i)).toBeInTheDocument();
+      });
+
+      const logAnotherButton = screen.getByRole('button', { name: /log another chore/i });
+      await act(async () => { logAnotherButton.focus(); });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(screen.getByText(/clean kitchen approved/i)).toBeInTheDocument();
+
+      await user.click(logAnotherButton);
+
+      expect(screen.queryByText(/clean kitchen approved/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Pick a Chore')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Clean Kitchen'));
+      await user.click(screen.getByText('Quick Clean'));
+
+      await waitFor(() => {
+        expect(screen.getByText(/clean kitchen approved/i)).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.queryByText(/clean kitchen approved/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Pick a Chore')).toBeInTheDocument();
+    });
   });
 
   it('updates banner when pending log is approved via polling', async () => {


### PR DESCRIPTION
After logging a chore, the confirmation card ("Logged Do the Dishes for +10 pts / Waiting for approval...") took over the chore picker area and stayed there indefinitely. The child's only way to dismiss it was a small X button in the corner -- not obvious for a kid tapping through on an iPad.

This adds two paths back to the chore picker: a prominent "Log Another Chore" button on every confirmation card, and an auto-dismiss timer that clears terminal states (approved/rejected) after 5 seconds.

## Changes

- Add `AUTO_DISMISS_DELAY_MS` constant and `useEffect` timer that auto-clears approved/rejected confirmations after 5s
- Keep pending confirmations visible until the child acts (no auto-dismiss while awaiting approval)
- Suppress auto-dismiss during in-flight cancel mutations to prevent race conditions
- Pause auto-dismiss via `onFocus`/`onBlur` handlers when the confirmation card has keyboard/VoiceOver focus (WCAG 2.2.1 Timing Adjustable)
- Add "Log Another Chore" button (amber, `min-h-touch`) that clears `recentLog` and returns to the chore picker
- Show "Log Another Chore" alongside "Cancel" for pending logs so both actions are always reachable

## Testing

### Scenario 1: Log Another Chore button
1. Open the Chores section on the Today screen
2. Pick a chore and select a tier
3. Verify that the confirmation card shows a "Log Another Chore" button
4. Click "Log Another Chore"
5. Verify that the chore picker returns with the full chore list

### Scenario 2: Auto-dismiss on approved chore
1. Log a chore that doesn't require approval (or approve it quickly from admin)
2. Verify that the "approved" confirmation shows for ~5 seconds
3. Verify that the chore picker reappears automatically after the timer

### Scenario 3: Pending stays visible
1. Log a chore that requires approval
2. Verify that the "Waiting for approval..." card stays visible past 5 seconds
3. Verify that both "Log Another Chore" and "Cancel" buttons are present

### Scenario 4: Focus pauses auto-dismiss
1. Log a chore that gets auto-approved
2. Tab or tap to focus the "Log Another Chore" button before the 5s timer
3. Verify that the confirmation card stays visible while focused
4. Blur focus away from the card
5. Verify that the auto-dismiss timer restarts and clears after 5s

---

### Reviewer Checklist

**UI changes:**
- [ ] WAVE accessibility tool passes
- [ ] Touch targets meet 44px minimum
- [ ] Works in Smart Invert / dark mode on iPad

Closes #110