### PR TITLE
Add routine health analytics to admin dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,7 +144,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1833,7 +1832,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1882,7 +1880,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -3913,6 +3910,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3926,6 +3924,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3940,7 +3939,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -4036,7 +4036,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4144,7 +4145,6 @@
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -4233,7 +4233,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4245,7 +4244,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4388,7 +4386,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -4704,7 +4701,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5262,7 +5258,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -5522,7 +5517,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6544,7 +6538,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -6849,7 +6844,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8712,7 +8706,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9086,6 +9079,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -10023,7 +10017,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10430,7 +10423,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10443,7 +10435,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10805,7 +10796,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12172,7 +12162,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12909,7 +12898,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13129,7 +13117,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -13683,7 +13670,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13845,7 +13831,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -23,6 +23,7 @@ import ApprovalsScreen from "./features/admin/approvals/ApprovalsScreen.js";
 import LedgerScreen from "./features/admin/ledger/LedgerScreen.js";
 import ActivityLogScreen from "./features/admin/activity/ActivityLogScreen.js";
 import SettingsScreen from "./features/admin/settings/SettingsScreen.js";
+import AdminDashboard from "./features/admin/dashboard/AdminDashboard.js";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -86,15 +87,6 @@ function AppShell() {
   );
 }
 
-function AdminPlaceholder({ title }: { title: string }) {
-  return (
-    <div className="rounded-2xl bg-[var(--color-surface)] p-6 shadow-card">
-      <h2 className="font-display text-xl font-semibold text-[var(--color-text)]">{title}</h2>
-      <p className="mt-2 text-[var(--color-text-muted)]">Coming soon.</p>
-    </div>
-  );
-}
-
 function AppRoutes() {
   useManifestLink();
 
@@ -116,7 +108,7 @@ function AppRoutes() {
 
         <Route element={<AdminGuard />}>
           <Route element={<AdminLayout />}>
-            <Route path="/admin" element={<AdminPlaceholder title="Admin Dashboard" />} />
+            <Route path="/admin" element={<AdminDashboard />} />
             <Route path="/admin/routines" element={<AdminRoutinesList />} />
             <Route path="/admin/routines/new" element={<AdminRoutineForm />} />
             <Route path="/admin/routines/:id/edit" element={<AdminRoutineForm />} />

--- a/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
+++ b/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
@@ -1,0 +1,566 @@
+import { Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../../api/client.js";
+import { useOnline } from "../../../contexts/OnlineContext.js";
+import { queryKeys, invalidatePointsRelated } from "../../../lib/query-keys.js";
+import { useAdminTimezone } from "../hooks/useAdminTimezone.js";
+import { formatTimestamp } from "../../../lib/format-timestamp.js";
+import type {
+  PendingApprovals,
+  RoutineCompletion,
+  ChoreLog,
+  RewardRequest,
+  ApprovalType,
+  ActivityEventType,
+  ActivityLogEntry,
+  PointsBalance,
+  LedgerEntry,
+} from "@chore-app/shared";
+
+interface ActivityLogResponse {
+  events: ActivityLogEntry[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+interface LedgerResponse {
+  entries: LedgerEntry[];
+  balance: PointsBalance;
+}
+
+const RECENT_ACTIVITY_LIMIT = 5;
+const APPROVALS_PER_TYPE = 5;
+
+const DATETIME_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+};
+
+const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+};
+
+function useDashboardApprovals(isOnline: boolean) {
+  return useQuery({
+    queryKey: queryKeys.admin.approvals(),
+    queryFn: async () => {
+      const result = await api.get<PendingApprovals>("/api/admin/approvals");
+      if (!result.ok) throw result.error;
+      return result.data;
+    },
+    enabled: isOnline,
+  });
+}
+
+function useDashboardActivity(isOnline: boolean) {
+  return useQuery({
+    queryKey: queryKeys.admin.recentActivity(RECENT_ACTIVITY_LIMIT),
+    queryFn: async () => {
+      const params = new URLSearchParams({
+        limit: String(RECENT_ACTIVITY_LIMIT),
+        page: "0",
+      });
+      const result = await api.get<ActivityLogResponse>(
+        `/api/admin/activity-log?${params.toString()}`,
+      );
+      if (!result.ok) throw result.error;
+      return result.data;
+    },
+    enabled: isOnline,
+  });
+}
+
+function useDashboardPoints(isOnline: boolean) {
+  return useQuery({
+    queryKey: queryKeys.admin.ledger(),
+    queryFn: async () => {
+      const result = await api.get<LedgerResponse>(
+        "/api/admin/points/ledger?limit=1",
+      );
+      if (!result.ok) throw result.error;
+      return result.data.balance;
+    },
+    enabled: isOnline,
+  });
+}
+
+function useDashboardApprove() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      type,
+      id,
+    }: {
+      type: ApprovalType;
+      id: number;
+    }) => {
+      const result = await api.post<void>(
+        `/api/admin/approvals/${type}/${id}/approve`,
+      );
+      if (!result.ok) throw result.error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.approvals() });
+      queryClient.invalidateQueries({ queryKey: ["admin", "activity-log"] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.ledger() });
+      invalidatePointsRelated(queryClient);
+    },
+  });
+}
+
+interface ApprovalItemProps {
+  name: string;
+  points: number;
+  isDeduction: boolean;
+  submittedAt: string;
+  type: ApprovalType;
+  id: number;
+  approveMutation: ReturnType<typeof useDashboardApprove>;
+  isOnline: boolean;
+  timezone: string;
+}
+
+function ApprovalItem({
+  name,
+  points,
+  isDeduction,
+  submittedAt,
+  type,
+  id,
+  approveMutation,
+  isOnline,
+  timezone,
+}: ApprovalItemProps) {
+  const isThisPending =
+    approveMutation.isPending &&
+    approveMutation.variables?.type === type &&
+    approveMutation.variables?.id === id;
+
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-[var(--color-border-light)] py-2.5 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium text-[var(--color-text)]">
+          {name}
+        </p>
+        <p className="text-xs text-[var(--color-text-muted)]">
+          {isDeduction ? `-${points}` : `+${points}`} pts
+          <span className="mx-1">&middot;</span>
+          {formatTimestamp(submittedAt, DATE_OPTIONS, timezone)}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => approveMutation.mutate({ type, id })}
+        disabled={!isOnline || isThisPending}
+        title={!isOnline ? "You're offline" : undefined}
+        className="shrink-0 rounded-lg bg-[var(--color-emerald-500)] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-[var(--color-emerald-600)] disabled:opacity-50"
+      >
+        {isThisPending ? "..." : "Approve"}
+      </button>
+    </div>
+  );
+}
+
+interface ApprovalTypeSectionProps {
+  label: string;
+  dotColor: string;
+  items: Array<{
+    id: number;
+    name: string;
+    points: number;
+    isDeduction: boolean;
+    submittedAt: string;
+    type: ApprovalType;
+  }>;
+  approveMutation: ReturnType<typeof useDashboardApprove>;
+  isOnline: boolean;
+  timezone: string;
+}
+
+function ApprovalTypeSection({
+  label,
+  dotColor,
+  items,
+  approveMutation,
+  isOnline,
+  timezone,
+}: ApprovalTypeSectionProps) {
+  if (items.length === 0) return null;
+
+  const visible = items.slice(0, APPROVALS_PER_TYPE);
+  const overflowCount = items.length - APPROVALS_PER_TYPE;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center gap-2">
+        <span className={`inline-block h-2 w-2 rounded-full ${dotColor}`} />
+        <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+          {label}
+        </span>
+      </div>
+      {visible.map((item) => (
+        <ApprovalItem
+          key={`${item.type}-${item.id}`}
+          {...item}
+          approveMutation={approveMutation}
+          isOnline={isOnline}
+          timezone={timezone}
+        />
+      ))}
+      {overflowCount > 0 && (
+        <Link
+          to="/admin/approvals"
+          className="mt-1 block text-xs font-semibold text-[var(--color-amber-700)] hover:underline"
+        >
+          {overflowCount} more &mdash; See all
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function PendingApprovalsCard({
+  data,
+  isLoading,
+  error,
+  isOnline,
+  timezone,
+  approveMutation,
+}: {
+  data: PendingApprovals | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  isOnline: boolean;
+  timezone: string;
+  approveMutation: ReturnType<typeof useDashboardApprove>;
+}) {
+  const routineItems = (data?.routineCompletions ?? []).map(
+    (item: RoutineCompletion) => ({
+      id: item.id,
+      name: item.routineNameSnapshot,
+      points: item.pointsSnapshot,
+      isDeduction: false,
+      submittedAt: item.completedAt,
+      type: "routine-completion" as const,
+    }),
+  );
+
+  const choreItems = (data?.choreLogs ?? []).map((item: ChoreLog) => ({
+    id: item.id,
+    name: item.choreNameSnapshot,
+    points: item.pointsSnapshot,
+    isDeduction: false,
+    submittedAt: item.loggedAt,
+    type: "chore-log" as const,
+  }));
+
+  const rewardItems = (data?.rewardRequests ?? []).map(
+    (item: RewardRequest) => ({
+      id: item.id,
+      name: item.rewardNameSnapshot,
+      points: item.costSnapshot,
+      isDeduction: true,
+      submittedAt: item.requestedAt,
+      type: "reward-request" as const,
+    }),
+  );
+
+  const totalPending =
+    routineItems.length + choreItems.length + rewardItems.length;
+
+  return (
+    <section
+      aria-label="Pending approvals"
+      className="rounded-2xl bg-[var(--color-surface)] p-5 shadow-card"
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-semibold text-[var(--color-text)]">
+          Pending Approvals
+        </h2>
+        {data && totalPending > 0 && (
+          <span className="rounded-full bg-[var(--color-amber-50)] px-2.5 py-0.5 font-display text-sm font-bold text-[var(--color-amber-700)]">
+            {totalPending}
+          </span>
+        )}
+      </div>
+
+      {isLoading && (
+        <div className="mt-4 animate-pulse space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-10 rounded bg-[var(--color-surface-muted)]" />
+          ))}
+          <div aria-live="polite" className="sr-only">Loading approvals...</div>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">
+          Could not load approvals.
+        </p>
+      )}
+
+      {approveMutation.error && (
+        <div className="mt-3 rounded-lg border border-[var(--color-red-600)] px-3 py-2" role="alert">
+          <p className="text-xs font-medium text-[var(--color-red-600)]">
+            Approval failed. Please try again.
+          </p>
+        </div>
+      )}
+
+      {data && totalPending === 0 && (
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">
+          Nothing pending
+        </p>
+      )}
+
+      {data && totalPending > 0 && (
+        <div className="mt-3 space-y-3">
+          <ApprovalTypeSection
+            label="Routines"
+            dotColor="bg-[var(--color-sky-500)]"
+            items={routineItems}
+            approveMutation={approveMutation}
+            isOnline={isOnline}
+            timezone={timezone}
+          />
+          <ApprovalTypeSection
+            label="Chores"
+            dotColor="bg-[var(--color-amber-500)]"
+            items={choreItems}
+            approveMutation={approveMutation}
+            isOnline={isOnline}
+            timezone={timezone}
+          />
+          <ApprovalTypeSection
+            label="Rewards"
+            dotColor="bg-[var(--color-amber-700)]"
+            items={rewardItems}
+            approveMutation={approveMutation}
+            isOnline={isOnline}
+            timezone={timezone}
+          />
+        </div>
+      )}
+
+      {data && totalPending > 0 && (
+        <Link
+          to="/admin/approvals"
+          className="mt-4 block text-center text-sm font-semibold text-[var(--color-amber-700)] hover:underline"
+        >
+          View full queue
+        </Link>
+      )}
+    </section>
+  );
+}
+
+function eventTypeDotColor(eventType: ActivityEventType): string {
+  if (eventType.startsWith("routine_")) return "bg-[var(--color-sky-500)]";
+  if (eventType.startsWith("chore_")) return "bg-[var(--color-amber-500)]";
+  if (eventType.startsWith("reward_")) return "bg-[var(--color-amber-700)]";
+  return "bg-[var(--color-text-muted)]";
+}
+
+function RecentActivityCard({
+  data,
+  isLoading,
+  error,
+  timezone,
+}: {
+  data: ActivityLogResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  timezone: string;
+}) {
+  const events = data?.events ?? [];
+
+  return (
+    <section
+      aria-label="Recent activity"
+      className="rounded-2xl bg-[var(--color-surface)] p-5 shadow-card"
+    >
+      <h2 className="font-display text-lg font-semibold text-[var(--color-text)]">
+        Recent Activity
+      </h2>
+
+      {isLoading && (
+        <div className="mt-4 animate-pulse space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-4 rounded bg-[var(--color-surface-muted)]" />
+          ))}
+          <div aria-live="polite" className="sr-only">Loading activity...</div>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">
+          Could not load activity.
+        </p>
+      )}
+
+      {data && events.length === 0 && (
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">
+          No recent activity
+        </p>
+      )}
+
+      {events.length > 0 && (
+        <ul className="mt-3 space-y-2.5">
+          {events.map((event) => (
+            <li key={event.id} className="flex items-start gap-2.5">
+              <span
+                className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${eventTypeDotColor(event.eventType)}`}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-[var(--color-text)]">
+                  {event.summary ?? event.eventType.replace(/_/g, " ")}
+                </p>
+                <p className="text-xs text-[var(--color-text-muted)]">
+                  {formatTimestamp(event.createdAt, DATETIME_OPTIONS, timezone)}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {events.length > 0 && (
+        <Link
+          to="/admin/activity"
+          className="mt-4 block text-center text-sm font-semibold text-[var(--color-amber-700)] hover:underline"
+        >
+          View all activity
+        </Link>
+      )}
+    </section>
+  );
+}
+
+function PointsBalanceCard({
+  data,
+  isLoading,
+  error,
+}: {
+  data: PointsBalance | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  return (
+    <section
+      aria-label="Points balance"
+      className="rounded-2xl bg-[var(--color-surface)] p-5 shadow-card"
+    >
+      <h2 className="font-display text-lg font-semibold text-[var(--color-text)]">
+        Points Balance
+      </h2>
+
+      {isLoading && (
+        <div className="mt-4 animate-pulse space-y-2">
+          <div className="h-10 w-24 rounded bg-[var(--color-surface-muted)]" />
+          <div className="h-4 w-40 rounded bg-[var(--color-surface-muted)]" />
+          <div aria-live="polite" className="sr-only">Loading points...</div>
+        </div>
+      )}
+
+      {error && (
+        <p className="mt-3 text-sm text-[var(--color-text-muted)]">
+          Could not load points.
+        </p>
+      )}
+
+      {data && (
+        <div className="mt-3">
+          <p className="font-display text-4xl font-bold text-[var(--color-amber-700)]">
+            {data.available}
+          </p>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            available points
+          </p>
+          <div className="mt-3 flex gap-4 text-sm">
+            <div>
+              <span className="font-semibold text-[var(--color-text-secondary)]">
+                {data.total}
+              </span>{" "}
+              <span className="text-[var(--color-text-muted)]">earned</span>
+            </div>
+            <div>
+              <span className="font-semibold text-[var(--color-text-secondary)]">
+                {data.reserved}
+              </span>{" "}
+              <span className="text-[var(--color-text-muted)]">reserved</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {data && (
+        <Link
+          to="/admin/ledger"
+          className="mt-4 block text-center text-sm font-semibold text-[var(--color-amber-700)] hover:underline"
+        >
+          View ledger
+        </Link>
+      )}
+    </section>
+  );
+}
+
+export default function AdminDashboard() {
+  const isOnline = useOnline();
+  const timezone = useAdminTimezone();
+
+  const approvals = useDashboardApprovals(isOnline);
+  const activity = useDashboardActivity(isOnline);
+  const points = useDashboardPoints(isOnline);
+  const approveMutation = useDashboardApprove();
+
+  return (
+    <div>
+      <h1 className="font-display text-2xl font-bold text-[var(--color-text)]">
+        Dashboard
+      </h1>
+
+      {!isOnline && !approvals.data && !activity.data && !points.data && (
+        <div className="mt-6 rounded-2xl bg-[var(--color-surface)] p-6 text-center shadow-card" aria-live="polite">
+          <p className="font-display text-lg font-bold text-[var(--color-text-secondary)]">
+            You're offline
+          </p>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+            The dashboard requires an internet connection to load.
+          </p>
+        </div>
+      )}
+
+      <div className="mt-6 grid grid-cols-1 gap-5 tablet:grid-cols-2">
+        <PointsBalanceCard
+          data={points.data}
+          isLoading={points.isLoading}
+          error={points.error}
+        />
+
+        <RecentActivityCard
+          data={activity.data}
+          isLoading={activity.isLoading}
+          error={activity.error}
+          timezone={timezone}
+        />
+
+        <div className="tablet:col-span-2">
+          <PendingApprovalsCard
+            data={approvals.data}
+            isLoading={approvals.isLoading}
+            error={approvals.error}
+            isOnline={isOnline}
+            timezone={timezone}
+            approveMutation={approveMutation}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/lib/query-keys.ts
+++ b/packages/client/src/lib/query-keys.ts
@@ -29,6 +29,8 @@ export const queryKeys = {
         : (["admin", "ledger"] as const),
     assets: (filters: Record<string, string>) =>
       ["admin", "assets", filters] as const,
+    recentActivity: (limit: number) =>
+      ["admin", "activity-log", "recent", limit] as const,
     activityLog: (
       eventType: string,
       startDate: string,

--- a/packages/client/tests/features/admin/dashboard/AdminDashboard.test.tsx
+++ b/packages/client/tests/features/admin/dashboard/AdminDashboard.test.tsx
@@ -1,0 +1,332 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { http, HttpResponse } from "msw";
+import { server } from "../../../msw/server.js";
+import AdminDashboard from "../../../../src/features/admin/dashboard/AdminDashboard.js";
+
+const mockPendingApprovals = {
+  routineCompletions: [
+    {
+      id: 1,
+      routineId: 1,
+      routineNameSnapshot: "Morning Routine",
+      timeSlotSnapshot: "morning",
+      completionRuleSnapshot: "once_per_day",
+      pointsSnapshot: 5,
+      requiresApprovalSnapshot: true,
+      checklistSnapshotJson: null,
+      randomizedOrderJson: null,
+      completionWindowKey: null,
+      completedAt: "2026-03-15T08:00:00",
+      localDate: "2026-03-15",
+      status: "pending",
+      idempotencyKey: "key-1",
+    },
+  ],
+  choreLogs: [
+    {
+      id: 2,
+      choreId: 1,
+      choreNameSnapshot: "Clean Kitchen",
+      tierId: 1,
+      tierNameSnapshot: "Quick Clean",
+      pointsSnapshot: 3,
+      requiresApprovalSnapshot: true,
+      loggedAt: "2026-03-15T10:00:00",
+      localDate: "2026-03-15",
+      status: "pending",
+      idempotencyKey: "key-2",
+    },
+  ],
+  rewardRequests: [
+    {
+      id: 3,
+      rewardId: 1,
+      rewardNameSnapshot: "Extra Screen Time",
+      costSnapshot: 20,
+      requestedAt: "2026-03-15T11:00:00",
+      localDate: "2026-03-15",
+      status: "pending",
+      idempotencyKey: "key-3",
+    },
+  ],
+};
+
+const mockActivityLog = {
+  events: [
+    {
+      id: 10,
+      eventType: "routine_submitted",
+      entityType: "routine_completion",
+      entityId: 1,
+      summary: "Completed Morning Routine for 5 points",
+      createdAt: "2026-03-15T12:00:00",
+    },
+    {
+      id: 11,
+      eventType: "chore_submitted",
+      entityType: "chore_log",
+      entityId: 2,
+      summary: "Logged Clean Kitchen (Quick Clean) for 3 points",
+      createdAt: "2026-03-15T11:00:00",
+    },
+  ],
+  total: 2,
+  page: 0,
+  limit: 5,
+};
+
+const mockBalance = { total: 150, reserved: 20, available: 130 };
+
+function setupHandlers() {
+  server.use(
+    http.get("/api/admin/approvals", () =>
+      HttpResponse.json({ data: mockPendingApprovals }),
+    ),
+    http.get("/api/admin/activity-log", () =>
+      HttpResponse.json({ data: mockActivityLog }),
+    ),
+    http.get("/api/admin/points/ledger", () =>
+      HttpResponse.json({
+        data: { entries: [], balance: mockBalance },
+      }),
+    ),
+    http.get("/api/admin/settings", () =>
+      HttpResponse.json({
+        data: { timezone: "America/Chicago" },
+      }),
+    ),
+  );
+}
+
+function renderDashboard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/admin"]}>
+        <AdminDashboard />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AdminDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupHandlers();
+  });
+
+  it("renders the dashboard heading", () => {
+    renderDashboard();
+    expect(screen.getByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons then resolves data", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("130")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("available points")).toBeInTheDocument();
+    expect(screen.getByText("150")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+  });
+
+  it("renders points balance card with earned and reserved", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("130")).toBeInTheDocument();
+    });
+
+    const balanceSection = screen.getByRole("region", { name: "Points balance" });
+    expect(within(balanceSection).getByText("150")).toBeInTheDocument();
+    expect(within(balanceSection).getByText("earned")).toBeInTheDocument();
+    expect(within(balanceSection).getByText("20")).toBeInTheDocument();
+    expect(within(balanceSection).getByText("reserved")).toBeInTheDocument();
+  });
+
+  it("renders recent activity events", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Completed Morning Routine for 5 points"),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Logged Clean Kitchen (Quick Clean) for 3 points"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders pending approvals grouped by type", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Clean Kitchen")).toBeInTheDocument();
+    expect(screen.getByText("Extra Screen Time")).toBeInTheDocument();
+  });
+
+  it("shows pending count badge", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+
+  it("approves an item and invalidates queries", async () => {
+    let approveCallCount = 0;
+
+    server.use(
+      http.post("/api/admin/approvals/:type/:id/approve", () => {
+        approveCallCount++;
+        return HttpResponse.json({ data: null });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+
+    const approveButtons = screen.getAllByRole("button", { name: "Approve" });
+    await user.click(approveButtons[0]);
+
+    await waitFor(() => {
+      expect(approveCallCount).toBe(1);
+    });
+  });
+
+  it("shows empty states when no data exists", async () => {
+    server.use(
+      http.get("/api/admin/approvals", () =>
+        HttpResponse.json({
+          data: { routineCompletions: [], choreLogs: [], rewardRequests: [] },
+        }),
+      ),
+      http.get("/api/admin/activity-log", () =>
+        HttpResponse.json({
+          data: { events: [], total: 0, page: 0, limit: 5 },
+        }),
+      ),
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Nothing pending")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("No recent activity")).toBeInTheDocument();
+  });
+
+  it("shows error messages when API calls fail", async () => {
+    server.use(
+      http.get("/api/admin/approvals", () =>
+        HttpResponse.json(
+          { error: { code: "SERVER_ERROR", message: "fail" } },
+          { status: 500 },
+        ),
+      ),
+      http.get("/api/admin/activity-log", () =>
+        HttpResponse.json(
+          { error: { code: "SERVER_ERROR", message: "fail" } },
+          { status: 500 },
+        ),
+      ),
+      http.get("/api/admin/points/ledger", () =>
+        HttpResponse.json(
+          { error: { code: "SERVER_ERROR", message: "fail" } },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not load approvals.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Could not load activity.")).toBeInTheDocument();
+    expect(screen.getByText("Could not load points.")).toBeInTheDocument();
+  });
+
+  it("renders navigation links to detail screens", async () => {
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("View full queue")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("View all activity")).toBeInTheDocument();
+    expect(screen.getByText("View ledger")).toBeInTheDocument();
+
+    expect(screen.getByText("View full queue").closest("a")).toHaveAttribute(
+      "href",
+      "/admin/approvals",
+    );
+    expect(screen.getByText("View all activity").closest("a")).toHaveAttribute(
+      "href",
+      "/admin/activity",
+    );
+    expect(screen.getByText("View ledger").closest("a")).toHaveAttribute(
+      "href",
+      "/admin/ledger",
+    );
+  });
+
+  it("shows overflow link when more than 5 items in a type", async () => {
+    const manyRoutines = Array.from({ length: 7 }, (_, i) => ({
+      id: i + 100,
+      routineId: 1,
+      routineNameSnapshot: `Routine ${i + 1}`,
+      timeSlotSnapshot: "morning",
+      completionRuleSnapshot: "once_per_day",
+      pointsSnapshot: 5,
+      requiresApprovalSnapshot: true,
+      checklistSnapshotJson: null,
+      randomizedOrderJson: null,
+      completionWindowKey: null,
+      completedAt: "2026-03-15T08:00:00",
+      localDate: "2026-03-15",
+      status: "pending",
+      idempotencyKey: `key-${i}`,
+    }));
+
+    server.use(
+      http.get("/api/admin/approvals", () =>
+        HttpResponse.json({
+          data: {
+            routineCompletions: manyRoutines,
+            choreLogs: [],
+            rewardRequests: [],
+          },
+        }),
+      ),
+    );
+
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByText("Routine 1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Routine 5")).toBeInTheDocument();
+    expect(screen.queryByText("Routine 6")).not.toBeInTheDocument();
+    expect(screen.getByText(/2 more/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds routine health analytics as the first dashboard analytics widget (issue #98)
- New `GET /api/admin/routine-analytics` endpoint with rolling 7-day completion rates, time-slot breakdown, and consecutive streak tracking
- Summary card on the admin dashboard showing worst-performing routines and neglected routine warnings
- Dedicated detail page at `/admin/routine-health` with full breakdowns and slot analysis
- Shared `useRoutineHealth` hook with 5-minute staleTime to avoid redundant fetches

## Changes

**Server (3 new files + 1 modified)**
- `routineAnalyticsService.ts` — analytics service with 3 cached prepared statements (active routines, combined completion/slot query, streak query)
- `admin-routine-analytics.ts` — GET route computing timezone-aware `localToday` from settings
- `app.ts` — wires new service and route behind adminAuth

**Client (4 new files + 3 modified)**
- `useRoutineHealth.ts` — shared TanStack Query hook used by both dashboard card and detail page
- `RoutineHealthCard` in `AdminDashboard.tsx` — summary card with streak pill, completion bars, neglected warning
- `RoutineHealthScreen.tsx` — detail page with streak, completion rates table, neglected alert, slot breakdown
- `App.tsx` + `query-keys.ts` — route registration and query key

**Shared (2 modified)**
- `types.ts` — `RoutineCompletionRate`, `TimeSlotBreakdown`, `RoutineHealthAnalytics` interfaces

## Test plan

- [ ] Server service tests: completion rates, slot breakdown, streak calculation, edge cases (archived routines, non-approved statuses, empty DB, streak gap, streak not anchored to today)
- [ ] Server route tests: 200 shape, 401 without session, active routine count, timezone fallback, 500 error propagation
- [ ] Client dashboard tests: card renders streak + rates, neglected warning, "View details" link, error state
- [ ] Client detail page tests: all sections render, neglected routines hidden when none, error with retry button, loading skeleton
- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — clean
- [ ] `npm run test -- --run` — 1143 passed