### PR TITLE
Add bonus points approve button to admin dashboard

### DIFF
--- a/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
+++ b/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
@@ -4,6 +4,7 @@ import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
 import { queryKeys, invalidatePointsRelated } from "../../../lib/query-keys.js";
 import { useAdminTimezone } from "../hooks/useAdminTimezone.js";
+import { useAdminSettings } from "../hooks/useAdminSettings.js";
 import { useRoutineHealth } from "../hooks/useRoutineHealth.js";
 import { useChoreEngagement } from "../hooks/useChoreEngagement.js";
 import { formatTimestamp } from "../../../lib/format-timestamp.js";
@@ -99,12 +100,17 @@ function useDashboardApprove() {
     mutationFn: async ({
       type,
       id,
+      bonusPoints,
     }: {
       type: ApprovalType;
       id: number;
+      bonusPoints?: number;
     }) => {
+      const body =
+        bonusPoints && bonusPoints > 0 ? { bonusPoints } : undefined;
       const result = await api.post<void>(
         `/api/admin/approvals/${type}/${id}/approve`,
+        body,
       );
       if (!result.ok) throw result.error;
     },
@@ -127,6 +133,7 @@ interface ApprovalItemProps {
   approveMutation: ReturnType<typeof useDashboardApprove>;
   isOnline: boolean;
   timezone: string;
+  bonusAmount: number;
 }
 
 function ApprovalItem({
@@ -139,11 +146,14 @@ function ApprovalItem({
   approveMutation,
   isOnline,
   timezone,
+  bonusAmount,
 }: ApprovalItemProps) {
   const isThisPending =
     approveMutation.isPending &&
     approveMutation.variables?.type === type &&
     approveMutation.variables?.id === id;
+
+  const isBonusEligible = type !== "reward-request" && bonusAmount > 0;
 
   return (
     <div className="flex items-center justify-between gap-3 border-b border-[var(--color-border-light)] py-2.5 last:border-b-0">
@@ -157,15 +167,34 @@ function ApprovalItem({
           {formatTimestamp(submittedAt, DATE_OPTIONS, timezone)}
         </p>
       </div>
-      <button
-        type="button"
-        onClick={() => approveMutation.mutate({ type, id })}
-        disabled={!isOnline || isThisPending}
-        title={!isOnline ? "You're offline" : undefined}
-        className="shrink-0 rounded-lg bg-[var(--color-emerald-500)] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-[var(--color-emerald-600)] disabled:opacity-50"
-      >
-        {isThisPending ? "..." : "Approve"}
-      </button>
+      <div className="flex shrink-0 gap-2">
+        <button
+          type="button"
+          onClick={() => approveMutation.mutate({ type, id })}
+          disabled={!isOnline || isThisPending}
+          title={!isOnline ? "You're offline" : undefined}
+          className="shrink-0 rounded-lg bg-[var(--color-emerald-500)] px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-[var(--color-emerald-600)] disabled:opacity-50"
+        >
+          {isThisPending && !approveMutation.variables?.bonusPoints
+            ? "..."
+            : "Approve"}
+        </button>
+        {isBonusEligible && (
+          <button
+            type="button"
+            onClick={() =>
+              approveMutation.mutate({ type, id, bonusPoints: bonusAmount })
+            }
+            disabled={!isOnline || isThisPending}
+            title={!isOnline ? "You're offline" : undefined}
+            className="shrink-0 rounded-lg border-2 border-[var(--color-amber-500)] bg-[var(--color-surface)] px-3 py-1.5 text-xs font-bold text-[var(--color-amber-700)] transition-colors hover:bg-[var(--color-amber-50)] disabled:opacity-50"
+          >
+            {isThisPending && approveMutation.variables?.bonusPoints
+              ? "..."
+              : `+Bonus (+${bonusAmount})`}
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -184,6 +213,7 @@ interface ApprovalTypeSectionProps {
   approveMutation: ReturnType<typeof useDashboardApprove>;
   isOnline: boolean;
   timezone: string;
+  bonusAmount: number;
 }
 
 function ApprovalTypeSection({
@@ -193,6 +223,7 @@ function ApprovalTypeSection({
   approveMutation,
   isOnline,
   timezone,
+  bonusAmount,
 }: ApprovalTypeSectionProps) {
   if (items.length === 0) return null;
 
@@ -214,6 +245,7 @@ function ApprovalTypeSection({
           approveMutation={approveMutation}
           isOnline={isOnline}
           timezone={timezone}
+          bonusAmount={bonusAmount}
         />
       ))}
       {overflowCount > 0 && (
@@ -235,6 +267,7 @@ function PendingApprovalsCard({
   isOnline,
   timezone,
   approveMutation,
+  bonusAmount,
 }: {
   data: PendingApprovals | undefined;
   isLoading: boolean;
@@ -242,6 +275,7 @@ function PendingApprovalsCard({
   isOnline: boolean;
   timezone: string;
   approveMutation: ReturnType<typeof useDashboardApprove>;
+  bonusAmount: number;
 }) {
   const routineItems = (data?.routineCompletions ?? []).map(
     (item: RoutineCompletion) => ({
@@ -331,6 +365,7 @@ function PendingApprovalsCard({
             approveMutation={approveMutation}
             isOnline={isOnline}
             timezone={timezone}
+            bonusAmount={bonusAmount}
           />
           <ApprovalTypeSection
             label="Chores"
@@ -339,6 +374,7 @@ function PendingApprovalsCard({
             approveMutation={approveMutation}
             isOnline={isOnline}
             timezone={timezone}
+            bonusAmount={bonusAmount}
           />
           <ApprovalTypeSection
             label="Rewards"
@@ -347,6 +383,7 @@ function PendingApprovalsCard({
             approveMutation={approveMutation}
             isOnline={isOnline}
             timezone={timezone}
+            bonusAmount={bonusAmount}
           />
         </div>
       )}
@@ -739,6 +776,8 @@ function RoutineHealthCard({
 export default function AdminDashboard() {
   const isOnline = useOnline();
   const timezone = useAdminTimezone();
+  const settingsQuery = useAdminSettings();
+  const bonusAmount = Number(settingsQuery.data?.bonus_approval_points) || 0;
 
   const approvals = useDashboardApprovals(isOnline);
   const activity = useDashboardActivity(isOnline);
@@ -802,6 +841,7 @@ export default function AdminDashboard() {
             isOnline={isOnline}
             timezone={timezone}
             approveMutation={approveMutation}
+            bonusAmount={bonusAmount}
           />
         </div>
       </div>

--- a/packages/client/tests/features/admin/dashboard/AdminDashboard.test.tsx
+++ b/packages/client/tests/features/admin/dashboard/AdminDashboard.test.tsx
@@ -376,6 +376,129 @@ describe("AdminDashboard", () => {
     expect(link.closest("a")).toHaveAttribute("href", "/admin/routine-health");
   });
 
+  describe("bonus approval button", () => {
+    function setupWithBonus(bonusPoints: string) {
+      server.use(
+        http.get("/api/admin/settings", () =>
+          HttpResponse.json({
+            data: { timezone: "America/Chicago", bonus_approval_points: bonusPoints },
+          }),
+        ),
+      );
+    }
+
+    it("shows bonus button for routines and chores when bonus_approval_points > 0", async () => {
+      setupWithBonus("5");
+      renderDashboard();
+
+      const approvalsSection = screen.getByRole("region", { name: "Pending approvals" });
+
+      await waitFor(() => {
+        expect(within(approvalsSection).getByText("Morning Routine")).toBeInTheDocument();
+      });
+
+      const bonusButtons = within(approvalsSection).getAllByRole("button", { name: /\+Bonus/ });
+      expect(bonusButtons).toHaveLength(2);
+      expect(bonusButtons[0]).toHaveTextContent("+Bonus (+5)");
+    });
+
+    it("hides bonus button for reward requests", async () => {
+      setupWithBonus("5");
+
+      server.use(
+        http.get("/api/admin/approvals", () =>
+          HttpResponse.json({
+            data: {
+              routineCompletions: [],
+              choreLogs: [],
+              rewardRequests: mockPendingApprovals.rewardRequests,
+            },
+          }),
+        ),
+      );
+
+      renderDashboard();
+
+      const approvalsSection = screen.getByRole("region", { name: "Pending approvals" });
+
+      await waitFor(() => {
+        expect(within(approvalsSection).getByText("Extra Screen Time")).toBeInTheDocument();
+      });
+
+      expect(within(approvalsSection).queryByRole("button", { name: /\+Bonus/ })).not.toBeInTheDocument();
+    });
+
+    it("hides bonus button when bonus_approval_points is 0", async () => {
+      setupWithBonus("0");
+      renderDashboard();
+
+      const approvalsSection = screen.getByRole("region", { name: "Pending approvals" });
+
+      await waitFor(() => {
+        expect(within(approvalsSection).getByText("Morning Routine")).toBeInTheDocument();
+      });
+
+      expect(within(approvalsSection).queryByRole("button", { name: /\+Bonus/ })).not.toBeInTheDocument();
+    });
+
+    it("sends bonusPoints in the request body when bonus button is clicked", async () => {
+      setupWithBonus("5");
+
+      let capturedBody: Record<string, unknown> | undefined;
+      server.use(
+        http.post("/api/admin/approvals/:type/:id/approve", async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json({ data: null });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderDashboard();
+
+      const approvalsSection = screen.getByRole("region", { name: "Pending approvals" });
+
+      await waitFor(() => {
+        expect(within(approvalsSection).getByText("Morning Routine")).toBeInTheDocument();
+      });
+
+      const bonusButtons = within(approvalsSection).getAllByRole("button", { name: /\+Bonus/ });
+      await user.click(bonusButtons[0]);
+
+      await waitFor(() => {
+        expect(capturedBody).toEqual({ bonusPoints: 5 });
+      });
+    });
+
+    it("sends no body when regular approve button is clicked", async () => {
+      setupWithBonus("5");
+
+      let capturedBody: unknown = "NOT_CALLED";
+      server.use(
+        http.post("/api/admin/approvals/:type/:id/approve", async ({ request }) => {
+          const text = await request.text();
+          capturedBody = text === "" ? undefined : JSON.parse(text);
+          return HttpResponse.json({ data: null });
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderDashboard();
+
+      const approvalsSection = screen.getByRole("region", { name: "Pending approvals" });
+
+      await waitFor(() => {
+        expect(within(approvalsSection).getByText("Morning Routine")).toBeInTheDocument();
+      });
+
+      const approveButtons = within(approvalsSection).getAllByRole("button", { name: "Approve" });
+      await user.click(approveButtons[0]);
+
+      await waitFor(() => {
+        expect(capturedBody).toBeUndefined();
+      });
+    });
+  });
+
   it("shows overflow link when more than 5 items in a type", async () => {
     const manyRoutines = Array.from({ length: 7 }, (_, i) => ({
       id: i + 100,


### PR DESCRIPTION
## Summary

The admin dashboard's pending approvals card only had a plain "Approve" button, while the full approvals screen already supported approving with bonus points. When `bonus_approval_points` is configured in admin settings, there was no way to grant bonus points from the dashboard's quick-action view.

- Extend `useDashboardApprove` mutation to accept optional `bonusPoints` and send it in the request body
- Render a "+Bonus (+N)" amber-styled button next to "Approve" for routine and chore items when `bonus_approval_points > 0`
- Hide the bonus button for reward requests (server doesn't support bonus on rewards)
- Fetch `bonus_approval_points` via `useAdminSettings` hook in the dashboard component
- Add 5 tests covering button visibility, eligibility rules, and request body contents

## Test plan

- Verify that the +Bonus button appears on routine and chore approval items when `bonus_approval_points` is set to a positive value in admin settings
- Verify that the +Bonus button does not appear on reward request items
- Verify that the +Bonus button does not appear when `bonus_approval_points` is 0 or unset
- Verify that clicking +Bonus sends `{ bonusPoints: N }` in the POST body
- Verify that clicking the regular Approve button sends no body
- Verify that all existing dashboard tests continue to pass