### PR TITLE
Move pending approvals to top of admin dashboard

### DIFF
--- a/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
+++ b/packages/client/src/features/admin/dashboard/AdminDashboard.tsx
@@ -804,6 +804,18 @@ export default function AdminDashboard() {
       )}
 
       <div className="mt-6 grid grid-cols-1 gap-5 tablet:grid-cols-2">
+        <div className="tablet:col-span-2">
+          <PendingApprovalsCard
+            data={approvals.data}
+            isLoading={approvals.isLoading}
+            error={approvals.error}
+            isOnline={isOnline}
+            timezone={timezone}
+            approveMutation={approveMutation}
+            bonusAmount={bonusAmount}
+          />
+        </div>
+
         <PointsBalanceCard
           data={points.data}
           isLoading={points.isLoading}
@@ -830,18 +842,6 @@ export default function AdminDashboard() {
             data={choreEngagement.data}
             isLoading={choreEngagement.isLoading}
             error={choreEngagement.error}
-          />
-        </div>
-
-        <div className="tablet:col-span-2">
-          <PendingApprovalsCard
-            data={approvals.data}
-            isLoading={approvals.isLoading}
-            error={approvals.error}
-            isOnline={isOnline}
-            timezone={timezone}
-            approveMutation={approveMutation}
-            bonusAmount={bonusAmount}
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #138

The admin dashboard's most-used section — pending approvals — sat at the bottom of the page, below analytics cards that get checked less often. Scrolling past points balance, activity feed, routine health, and chore engagement just to approve a chore added unnecessary friction to the primary workflow.

## Changes

- Move `PendingApprovalsCard` from position 5 (last) to position 1 (first) in the dashboard grid
- No logic, prop, or styling changes — pure layout reorder

## Testing

1. Open the admin dashboard
2. Verify that Pending Approvals is the first card visible, above the fold
3. Verify that Points Balance and Recent Activity appear side-by-side below it
4. Verify that Routine Health and Chore Engagement follow in order
5. Verify that approve and +Bonus buttons still function correctly from the new position
6. Resize to mobile width — verify that all cards stack in the new order (approvals first)