### PR TITLE
Clone routines from existing routines

### DIFF
--- a/e2e/admin-approvals.spec.ts
+++ b/e2e/admin-approvals.spec.ts
@@ -57,7 +57,7 @@ test.describe("Admin Approval Queue", () => {
 
   test("setup: create a routine that requires approval", async () => {
     await createRoutineWithApproval(page, routineName);
-    await expect(page.getByRole("link", { name: routineName })).toBeVisible();
+    await expect(page.getByRole("link", { name: routineName, exact: true })).toBeVisible();
   });
 
   test("setup: submit the routine as a child", async () => {

--- a/e2e/admin-routines.spec.ts
+++ b/e2e/admin-routines.spec.ts
@@ -19,7 +19,7 @@ async function createRoutine(page: Page, name: string, points = 5) {
     page.getByRole("button", { name: "Save & Close" }).click(),
   ]);
   await page.waitForURL(/\/admin\/routines$/);
-  await expect(page.getByRole("link", { name })).toBeVisible();
+  await expect(page.getByRole("link", { name, exact: true })).toBeVisible();
 }
 
 function getRoutineRow(page: Page, name: string) {
@@ -73,7 +73,7 @@ test.describe("Admin Routines CRUD", () => {
     const updatedName = `Updated Routine ${TEST_RUN_SUFFIX}`;
     await createRoutine(page, name, 5);
 
-    await page.getByRole("link", { name }).click();
+    await page.getByRole("link", { name, exact: true }).click();
     await page.waitForURL(/\/admin\/routines\/\d+\/edit/);
 
     await expect(
@@ -145,7 +145,7 @@ test.describe("Admin Routines CRUD", () => {
     const name = `No Edit After Archive ${TEST_RUN_SUFFIX}`;
     await createRoutine(page, name, 4);
 
-    const editLink = page.getByRole("link", { name });
+    const editLink = page.getByRole("link", { name, exact: true });
     const href = await editLink.getAttribute("href");
     const routineId = href?.match(/\/admin\/routines\/(\d+)\/edit/)?.[1];
     expect(routineId).toBeTruthy();
@@ -225,6 +225,6 @@ test.describe("Admin Routines CRUD", () => {
       page.waitForURL(/\/admin\/routines$/),
       submitButton.click({ clickCount: 2 }),
     ]);
-    await expect(page.getByRole("link", { name })).toHaveCount(1);
+    await expect(page.getByRole("link", { name, exact: true })).toHaveCount(1);
   });
 });

--- a/e2e/clone-routine.spec.ts
+++ b/e2e/clone-routine.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+import { loginAsAdmin } from "./helpers/admin-auth.js";
+import { paceForRateLimiter } from "./helpers/rate-limiter.js";
+
+const TEST_RUN_SUFFIX = Date.now();
+
+function getRoutineRow(page: Page, name: string) {
+  return page.locator("tr", { hasText: name });
+}
+
+async function getRoutineIdFromRow(row: Locator, name: string) {
+  const href = await row.getByRole("link", { name, exact: true }).getAttribute("href");
+  const routineId = href?.match(/\/admin\/routines\/(\d+)\/edit/)?.[1];
+  if (!routineId) {
+    throw new Error(`Could not read routine id from href: ${href ?? "<missing>"}`);
+  }
+  return routineId;
+}
+
+async function createRoutineWithItems(
+  page: Page,
+  name: string,
+  items: string[],
+) {
+  await paceForRateLimiter(page);
+  await page.goto("/admin/routines/new");
+  await expect(page.getByRole("heading", { name: "New Routine" })).toBeVisible();
+
+  await page.getByLabel("Name").fill(name);
+  await page.getByLabel("Points").fill("");
+  await page.getByLabel("Points").fill("11");
+
+  for (const [index, item] of items.entries()) {
+    if (index > 0) {
+      await page.getByRole("button", { name: "+ Add Item" }).first().click();
+    }
+    await page.getByLabel(`Checklist item ${index + 1}`).fill(item);
+  }
+
+  await paceForRateLimiter(page);
+  await Promise.all([
+    page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/admin/routines") &&
+        resp.request().method() === "POST",
+    ),
+    page.getByRole("button", { name: "Save & Close" }).click(),
+  ]);
+  await page.waitForURL(/\/admin\/routines$/);
+  await expect(getRoutineRow(page, name)).toBeVisible();
+}
+
+async function getAdminRoutine(page: Page, routineId: string) {
+  const response = await page.request.get(`/api/admin/routines/${routineId}`);
+  expect(response.ok(), `GET routine ${routineId} failed`).toBe(true);
+  const body = await response.json();
+  return body.data as {
+    name: string;
+    items: { label: string; archivedAt?: string }[];
+  };
+}
+
+test.describe("Clone routine", () => {
+  test("clones a routine as an editable draft without changing the source", async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const sourceName = `School Source ${TEST_RUN_SUFFIX}`;
+    const cloneName = `Camp Clone ${TEST_RUN_SUFFIX}`;
+    const sourceItems = ["Pack backpack", "Fill water bottle", "Put shoes on"];
+
+    await createRoutineWithItems(page, sourceName, sourceItems);
+
+    const sourceRow = getRoutineRow(page, sourceName);
+    const sourceId = await getRoutineIdFromRow(sourceRow, sourceName);
+
+    await paceForRateLimiter(page);
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().includes(`/api/admin/routines/${sourceId}`) &&
+          resp.request().method() === "GET",
+      ),
+      sourceRow.getByRole("link", { name: `Clone ${sourceName}` }).click(),
+    ]);
+
+    await expect(page.getByRole("heading", { name: "Clone Routine" })).toBeVisible();
+    await expect(page.getByLabel("Name")).toHaveValue(`${sourceName} (Copy)`);
+    await expect(page.getByLabel("Checklist item 1")).toHaveValue(sourceItems[0]);
+    await expect(page.getByLabel("Checklist item 2")).toHaveValue(sourceItems[1]);
+    await expect(page.getByLabel("Checklist item 3")).toHaveValue(sourceItems[2]);
+
+    await page.getByRole("button", { name: "Remove item 2" }).click();
+    await page.getByRole("button", { name: "+ Add Item" }).first().click();
+    await page.getByLabel("Checklist item 3").fill("Grab swimsuit");
+    await page.getByLabel("Name").fill(cloneName);
+
+    await paceForRateLimiter(page);
+    await Promise.all([
+      page.waitForResponse(
+        (resp) =>
+          resp.url().includes("/api/admin/routines") &&
+          resp.request().method() === "POST",
+      ),
+      page.getByRole("button", { name: "Save & Close" }).click(),
+    ]);
+    await page.waitForURL(/\/admin\/routines$/);
+
+    const cloneRow = getRoutineRow(page, cloneName);
+    await expect(cloneRow).toBeVisible();
+    await expect(sourceRow).toBeVisible();
+
+    const cloneId = await getRoutineIdFromRow(cloneRow, cloneName);
+    const cloneRoutine = await getAdminRoutine(page, cloneId);
+    expect(cloneRoutine.name).toBe(cloneName);
+    expect(cloneRoutine.items.filter((item) => !item.archivedAt).map((item) => item.label)).toEqual([
+      "Pack backpack",
+      "Put shoes on",
+      "Grab swimsuit",
+    ]);
+
+    const sourceRoutine = await getAdminRoutine(page, sourceId);
+    expect(sourceRoutine.name).toBe(sourceName);
+    expect(sourceRoutine.items.filter((item) => !item.archivedAt).map((item) => item.label)).toEqual(sourceItems);
+  });
+});

--- a/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
@@ -70,6 +70,7 @@ function useExistingRoutine(id: string | undefined) {
       return result.data;
     },
     enabled: !!id,
+    refetchOnMount: "always",
   });
 }
 
@@ -96,7 +97,16 @@ export default function AdminRoutineForm() {
   const queryClient = useQueryClient();
 
   const isOnline = useOnline();
-  const { data: existing, isLoading: isLoadingExisting, error: loadError } = useExistingRoutine(sourceId);
+  const {
+    data: existing,
+    isFetchedAfterMount: isExistingFetchedAfterMount,
+    isLoading: isLoadingExisting,
+    error: loadError,
+  } = useExistingRoutine(sourceId);
+  const canPopulateFromExisting = !isCloning || isExistingFetchedAfterMount;
+  const isLoadingSource =
+    (isEditing && isLoadingExisting) ||
+    (isCloning && !canPopulateFromExisting && !loadError);
 
   const [form, setForm] = useState<FormState>(INITIAL_STATE);
   const [errors, setErrors] = useState<FormErrors>({});
@@ -113,7 +123,7 @@ export default function AdminRoutineForm() {
   }, []);
 
   useEffect(() => {
-    if (existing && sourceId && populatedSourceId !== sourceId) {
+    if (existing && sourceId && canPopulateFromExisting && populatedSourceId !== sourceId) {
       setForm({
         name: isCloning ? `${existing.name} (Copy)` : existing.name,
         timeSlot: existing.timeSlot,
@@ -137,7 +147,7 @@ export default function AdminRoutineForm() {
       });
       setPopulatedSourceId(sourceId);
     }
-  }, [existing, isCloning, populatedSourceId, sourceId]);
+  }, [canPopulateFromExisting, existing, isCloning, populatedSourceId, sourceId]);
 
   const createMutation = useMutation({
     mutationFn: async (data: FormState) => {
@@ -161,7 +171,8 @@ export default function AdminRoutineForm() {
       if (!result.ok) throw result.error;
       return result.data;
     },
-    onSuccess: () => {
+    onSuccess: (routine) => {
+      queryClient.setQueryData(queryKeys.admin.routine(String(routine.id)), routine);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.routines() });
     },
   });
@@ -200,7 +211,8 @@ export default function AdminRoutineForm() {
       if (!result.ok) throw result.error;
       return result.data;
     },
-    onSuccess: () => {
+    onSuccess: (routine) => {
+      queryClient.setQueryData(queryKeys.admin.routine(String(routine.id)), routine);
       queryClient.invalidateQueries({ queryKey: queryKeys.admin.routines() });
     },
   });
@@ -299,7 +311,7 @@ export default function AdminRoutineForm() {
     });
   }
 
-  if ((isEditing || isCloning) && isLoadingExisting) {
+  if (isLoadingSource) {
     return (
       <div>
         <div aria-live="polite" className="sr-only">Loading routine...</div>

--- a/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
@@ -100,7 +100,7 @@ export default function AdminRoutineForm() {
 
   const [form, setForm] = useState<FormState>(INITIAL_STATE);
   const [errors, setErrors] = useState<FormErrors>({});
-  const [hasPopulated, setHasPopulated] = useState(false);
+  const [populatedSourceId, setPopulatedSourceId] = useState<string | undefined>();
   const [isSaveSuccess, setSaveSuccess] = useState(false);
   const [saveIntent, setSaveIntent] = useState<"save" | "close" | null>(null);
   const successTimerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -113,7 +113,7 @@ export default function AdminRoutineForm() {
   }, []);
 
   useEffect(() => {
-    if (existing && !hasPopulated) {
+    if (existing && sourceId && populatedSourceId !== sourceId) {
       setForm({
         name: isCloning ? `${existing.name} (Copy)` : existing.name,
         timeSlot: existing.timeSlot,
@@ -135,9 +135,9 @@ export default function AdminRoutineForm() {
             imageUrl: item.imageUrl ?? null,
           })),
       });
-      setHasPopulated(true);
+      setPopulatedSourceId(sourceId);
     }
-  }, [existing, hasPopulated, isCloning]);
+  }, [existing, isCloning, populatedSourceId, sourceId]);
 
   const createMutation = useMutation({
     mutationFn: async (data: FormState) => {

--- a/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "../../../api/client.js";
 import { useOnline } from "../../../contexts/OnlineContext.js";
@@ -88,11 +88,15 @@ function validate(form: FormState): FormErrors {
 export default function AdminRoutineForm() {
   const { id } = useParams<{ id: string }>();
   const isEditing = !!id;
+  const [searchParams] = useSearchParams();
+  const cloneFromId = searchParams.get("cloneFrom") ?? undefined;
+  const isCloning = !id && !!cloneFromId;
+  const sourceId = id ?? cloneFromId;
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
   const isOnline = useOnline();
-  const { data: existing, isLoading: isLoadingExisting, error: loadError } = useExistingRoutine(id);
+  const { data: existing, isLoading: isLoadingExisting, error: loadError } = useExistingRoutine(sourceId);
 
   const [form, setForm] = useState<FormState>(INITIAL_STATE);
   const [errors, setErrors] = useState<FormErrors>({});
@@ -111,20 +115,20 @@ export default function AdminRoutineForm() {
   useEffect(() => {
     if (existing && !hasPopulated) {
       setForm({
-        name: existing.name,
+        name: isCloning ? `${existing.name} (Copy)` : existing.name,
         timeSlot: existing.timeSlot,
         completionRule: existing.completionRule,
         points: existing.points,
         requiresApproval: existing.requiresApproval,
         randomizeItems: existing.randomizeItems,
-        sortOrder: existing.sortOrder,
+        sortOrder: isCloning ? 0 : existing.sortOrder,
         imageAssetId: existing.imageAssetId ?? null,
         imageUrl: existing.imageUrl ?? null,
         items: existing.items
           .filter((item) => !item.archivedAt)
           .map((item) => ({
-            key: String(item.id),
-            serverId: item.id,
+            key: isCloning ? crypto.randomUUID() : String(item.id),
+            serverId: isCloning ? undefined : item.id,
             label: item.label,
             sortOrder: item.sortOrder,
             imageAssetId: item.imageAssetId ?? null,
@@ -133,7 +137,7 @@ export default function AdminRoutineForm() {
       });
       setHasPopulated(true);
     }
-  }, [existing, hasPopulated]);
+  }, [existing, hasPopulated, isCloning]);
 
   const createMutation = useMutation({
     mutationFn: async (data: FormState) => {
@@ -295,7 +299,7 @@ export default function AdminRoutineForm() {
     });
   }
 
-  if (isEditing && isLoadingExisting) {
+  if ((isEditing || isCloning) && isLoadingExisting) {
     return (
       <div>
         <div aria-live="polite" className="sr-only">Loading routine...</div>
@@ -307,7 +311,7 @@ export default function AdminRoutineForm() {
     );
   }
 
-  if (isEditing && loadError) {
+  if ((isEditing || isCloning) && loadError) {
     return (
       <div className="rounded-2xl bg-[var(--color-surface)] p-6 text-center shadow-card" aria-live="assertive">
         <p className="font-display text-lg font-bold text-[var(--color-text-secondary)]">
@@ -330,7 +334,7 @@ export default function AdminRoutineForm() {
   return (
     <div>
       <h1 className="font-display text-2xl font-bold text-[var(--color-text)]">
-        {isEditing ? "Edit Routine" : "New Routine"}
+        {isCloning ? "Clone Routine" : isEditing ? "Edit Routine" : "New Routine"}
       </h1>
 
       <form onSubmit={handleSubmit} noValidate className="mt-6 space-y-6">

--- a/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutineForm.tsx
@@ -61,6 +61,16 @@ const COMPLETION_RULE_OPTIONS: { value: CompletionRule; label: string }[] = [
   { value: "unlimited", label: "Unlimited" },
 ];
 
+const ROUTINE_NAME_MAX_LENGTH = 200;
+const CLONE_NAME_SUFFIX = " (Copy)";
+
+function getCloneRoutineName(name: string) {
+  const copyName = `${name}${CLONE_NAME_SUFFIX}`;
+  if (copyName.length <= ROUTINE_NAME_MAX_LENGTH) return copyName;
+
+  return `${name.slice(0, ROUTINE_NAME_MAX_LENGTH - CLONE_NAME_SUFFIX.length).trimEnd()}${CLONE_NAME_SUFFIX}`;
+}
+
 function useExistingRoutine(id: string | undefined) {
   return useQuery({
     queryKey: queryKeys.admin.routine(id),
@@ -78,6 +88,8 @@ function validate(form: FormState): FormErrors {
   const errors: FormErrors = {};
   if (!form.name.trim()) {
     errors.name = "Name is required";
+  } else if (form.name.trim().length > ROUTINE_NAME_MAX_LENGTH) {
+    errors.name = `Name must be ${ROUTINE_NAME_MAX_LENGTH} characters or fewer`;
   }
   const activeItems = form.items.filter((item) => item.label.trim());
   if (activeItems.length === 0) {
@@ -103,7 +115,7 @@ export default function AdminRoutineForm() {
     isLoading: isLoadingExisting,
     error: loadError,
   } = useExistingRoutine(sourceId);
-  const canPopulateFromExisting = !isCloning || isExistingFetchedAfterMount;
+  const canPopulateFromExisting = !isCloning || isExistingFetchedAfterMount || !!loadError;
   const isLoadingSource =
     (isEditing && isLoadingExisting) ||
     (isCloning && !canPopulateFromExisting && !loadError);
@@ -125,7 +137,7 @@ export default function AdminRoutineForm() {
   useEffect(() => {
     if (existing && sourceId && canPopulateFromExisting && populatedSourceId !== sourceId) {
       setForm({
-        name: isCloning ? `${existing.name} (Copy)` : existing.name,
+        name: isCloning ? getCloneRoutineName(existing.name) : existing.name,
         timeSlot: existing.timeSlot,
         completionRule: existing.completionRule,
         points: existing.points,
@@ -323,7 +335,7 @@ export default function AdminRoutineForm() {
     );
   }
 
-  if ((isEditing || isCloning) && loadError) {
+  if ((isEditing || isCloning) && loadError && !existing) {
     return (
       <div className="rounded-2xl bg-[var(--color-surface)] p-6 text-center shadow-card" aria-live="assertive">
         <p className="font-display text-lg font-bold text-[var(--color-text-secondary)]">

--- a/packages/client/src/features/admin/routines/AdminRoutinesList.tsx
+++ b/packages/client/src/features/admin/routines/AdminRoutinesList.tsx
@@ -187,19 +187,28 @@ export default function AdminRoutinesList() {
                       )}
                     </td>
                     <td className="px-4 py-3">
-                      <button
-                        type="button"
-                        onClick={() =>
-                          archiveToggle.mutate({
-                            id: routine.id,
-                            archived: !!routine.archivedAt,
-                          })
-                        }
-                        disabled={archiveToggle.isPending || !isOnline}
-                        className="min-h-touch rounded-lg px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-muted)] hover:text-[var(--color-text-secondary)] disabled:opacity-50"
-                      >
-                        {routine.archivedAt ? "Unarchive" : "Archive"}
-                      </button>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Link
+                          to={`/admin/routines/new?cloneFrom=${routine.id}`}
+                          aria-label={`Clone ${routine.name}`}
+                          className="inline-flex min-h-touch items-center rounded-lg px-3 py-2 text-xs font-medium text-[var(--color-sky-700)] transition-colors hover:bg-[var(--color-surface-muted)]"
+                        >
+                          Clone
+                        </Link>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            archiveToggle.mutate({
+                              id: routine.id,
+                              archived: !!routine.archivedAt,
+                            })
+                          }
+                          disabled={archiveToggle.isPending || !isOnline}
+                          className="min-h-touch rounded-lg px-3 py-2 text-xs font-medium text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-muted)] hover:text-[var(--color-text-secondary)] disabled:opacity-50"
+                        >
+                          {routine.archivedAt ? "Unarchive" : "Archive"}
+                        </button>
+                      </div>
                     </td>
                   </tr>
                 ))}

--- a/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
+++ b/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
@@ -63,11 +63,12 @@ const mockCloneSourceRoutine = {
 };
 
 const mockNavigate = vi.fn();
+let useRealNavigate = false;
 vi.mock("react-router-dom", async () => {
-  const actual = await vi.importActual("react-router-dom");
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
-    useNavigate: () => mockNavigate,
+    useNavigate: () => (useRealNavigate ? actual.useNavigate() : mockNavigate),
   };
 });
 
@@ -103,6 +104,25 @@ function renderCloneForm() {
   );
 }
 
+function renderCloneFormWithEditRoute() {
+  useRealNavigate = true;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/admin/routines/new?cloneFrom=1"]}>
+        <Routes>
+          <Route path="/admin/routines/new" element={<AdminRoutineForm />} />
+          <Route path="/admin/routines/:id/edit" element={<AdminRoutineForm />} />
+          <Route path="/admin/routines" element={<div>Routine list</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
 function renderEditForm() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -122,6 +142,7 @@ function renderEditForm() {
 describe("AdminRoutineForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useRealNavigate = false;
   });
 
   it("renders all fields for create mode", () => {
@@ -232,6 +253,77 @@ describe("AdminRoutineForm", () => {
     ]);
     expect(items.every((item) => !("id" in item))).toBe(true);
     expect(items.every((item) => !("imageUrl" in item))).toBe(true);
+  });
+
+  it("reloads a created clone before saving again from edit mode", async () => {
+    const persistedCloneRoutine = {
+      ...mockCloneSourceRoutine,
+      id: 99,
+      name: "Leave for School (Copy)",
+      sortOrder: 0,
+      items: [
+        {
+          id: 30,
+          routineId: 99,
+          label: "Pack backpack",
+          sortOrder: 0,
+          imageAssetId: 8,
+          imageUrl: "/assets/backpack.png",
+        },
+        {
+          id: 31,
+          routineId: 99,
+          label: "Fill water bottle",
+          sortOrder: 1,
+          imageAssetId: null,
+          imageUrl: null,
+        },
+      ],
+    };
+    let capturedUpdateBody: unknown;
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({ data: mockCloneSourceRoutine }),
+      ),
+      http.get("/api/admin/routines/99", () =>
+        HttpResponse.json({ data: persistedCloneRoutine }),
+      ),
+      http.post("/api/admin/routines", () =>
+        HttpResponse.json({ data: persistedCloneRoutine }, { status: 201 }),
+      ),
+      http.put("/api/admin/routines/99", async ({ request }) => {
+        capturedUpdateBody = await request.json();
+        return HttpResponse.json({ data: persistedCloneRoutine });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderCloneFormWithEditRoute();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Clone Routine" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Edit Routine" })).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save & Close" }));
+
+    await waitFor(() => {
+      expect(capturedUpdateBody).toBeTruthy();
+    });
+
+    const body = capturedUpdateBody as Record<string, unknown>;
+    expect(body.items).toEqual([
+      { id: 30, label: "Pack backpack", sortOrder: 0, imageAssetId: 8 },
+      { id: 31, label: "Fill water bottle", sortOrder: 1, imageAssetId: null },
+    ]);
   });
 
   it("can trim a clone draft before saving with reindexed item order", async () => {

--- a/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
+++ b/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
@@ -22,6 +22,46 @@ const mockExistingRoutine = {
   ],
 };
 
+const mockCloneSourceRoutine = {
+  id: 1,
+  name: "Leave for School",
+  timeSlot: "bedtime",
+  completionRule: "once_per_slot",
+  points: 12,
+  requiresApproval: true,
+  randomizeItems: true,
+  sortOrder: 4,
+  imageAssetId: 7,
+  imageUrl: "/assets/routine-school.png",
+  items: [
+    {
+      id: 20,
+      routineId: 1,
+      label: "Pack backpack",
+      sortOrder: 0,
+      imageAssetId: 8,
+      imageUrl: "/assets/backpack.png",
+    },
+    {
+      id: 21,
+      routineId: 1,
+      label: "Fill water bottle",
+      sortOrder: 1,
+      imageAssetId: null,
+      imageUrl: null,
+    },
+    {
+      id: 22,
+      routineId: 1,
+      label: "Archived school step",
+      sortOrder: 2,
+      archivedAt: "2026-06-01T12:00:00.000Z",
+      imageAssetId: 9,
+      imageUrl: "/assets/archived-step.png",
+    },
+  ],
+};
+
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
@@ -39,6 +79,22 @@ function renderCreateForm() {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={["/admin/routines/new"]}>
+        <Routes>
+          <Route path="/admin/routines/new" element={<AdminRoutineForm />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function renderCloneForm() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/admin/routines/new?cloneFrom=1"]}>
         <Routes>
           <Route path="/admin/routines/new" element={<AdminRoutineForm />} />
         </Routes>
@@ -101,6 +157,135 @@ describe("AdminRoutineForm", () => {
     expect(screen.getByDisplayValue("Brush teeth")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Make bed")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("loads a clone source as an unsaved draft with copied settings and images", async () => {
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({ data: mockCloneSourceRoutine }),
+      ),
+    );
+
+    renderCloneForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Clone Routine" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("Name")).toHaveValue("Leave for School (Copy)");
+    expect(screen.getByLabelText("Time Slot")).toHaveValue("bedtime");
+    expect(screen.getByLabelText("Completion Rule")).toHaveValue("once_per_slot");
+    expect(screen.getByLabelText("Points")).toHaveValue(12);
+    expect(screen.getByLabelText("Requires approval")).toBeChecked();
+    expect(screen.getByLabelText("Randomize items")).toBeChecked();
+    expect(screen.getByDisplayValue("Pack backpack")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Fill water bottle")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Image for Routine Image" })).toHaveAttribute(
+      "src",
+      "/assets/routine-school.png",
+    );
+    expect(screen.getByRole("img", { name: "Image for Image for item 1" })).toHaveAttribute(
+      "src",
+      "/assets/backpack.png",
+    );
+    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+  });
+
+  it("submits a clone as a fresh routine with copied asset ids and no source ids", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({ data: mockCloneSourceRoutine }),
+      ),
+      http.post("/api/admin/routines", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          { data: { ...mockCloneSourceRoutine, id: 99, name: "Leave for School (Copy)" } },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderCloneForm();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Leave for School (Copy)");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save & Close" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+
+    const body = capturedBody as Record<string, unknown>;
+    const items = body.items as Record<string, unknown>[];
+    expect(body).not.toHaveProperty("id");
+    expect(body).not.toHaveProperty("imageUrl");
+    expect(body.name).toBe("Leave for School (Copy)");
+    expect(body.sortOrder).toBe(0);
+    expect(body.imageAssetId).toBe(7);
+    expect(items).toEqual([
+      { label: "Pack backpack", sortOrder: 0, imageAssetId: 8 },
+      { label: "Fill water bottle", sortOrder: 1, imageAssetId: null },
+    ]);
+    expect(items.every((item) => !("id" in item))).toBe(true);
+    expect(items.every((item) => !("imageUrl" in item))).toBe(true);
+  });
+
+  it("can trim a clone draft before saving with reindexed item order", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({ data: mockCloneSourceRoutine }),
+      ),
+      http.post("/api/admin/routines", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json(
+          { data: { ...mockCloneSourceRoutine, id: 99, name: "Leave for Camp" } },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderCloneForm();
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Pack backpack")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove item 1" }));
+    await user.clear(screen.getByLabelText("Name"));
+    await user.type(screen.getByLabelText("Name"), "Leave for Camp");
+    await user.click(screen.getByRole("button", { name: "Save & Close" }));
+
+    await waitFor(() => {
+      expect(capturedBody).toBeTruthy();
+    });
+
+    const body = capturedBody as Record<string, unknown>;
+    expect(body.items).toEqual([
+      { label: "Fill water bottle", sortOrder: 0, imageAssetId: null },
+    ]);
+  });
+
+  it("excludes archived checklist items from a clone draft", async () => {
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({ data: mockCloneSourceRoutine }),
+      ),
+    );
+
+    renderCloneForm();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Leave for School (Copy)");
+    });
+
+    expect(screen.getByDisplayValue("Pack backpack")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Archived school step")).not.toBeInTheDocument();
   });
 
   it("submits create with correct data", async () => {

--- a/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
+++ b/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
@@ -122,9 +122,7 @@ function renderCloneFormWithEditRoute() {
   );
 }
 
-function renderEditForm() {
-  const queryClient = createTestQueryClient();
-
+function renderEditForm(queryClient = createTestQueryClient()) {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={["/admin/routines/1/edit"]}>
@@ -209,6 +207,28 @@ describe("AdminRoutineForm", () => {
     expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
   });
 
+  it("keeps generated clone names within the server limit", async () => {
+    const sourceName = "A".repeat(200);
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({
+          data: {
+            ...mockCloneSourceRoutine,
+            name: sourceName,
+          },
+        }),
+      ),
+    );
+
+    renderCloneForm();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue(`${"A".repeat(193)} (Copy)`);
+    });
+
+    expect((screen.getByLabelText("Name") as HTMLInputElement).value).toHaveLength(200);
+  });
+
   it("refreshes stale cached source data before populating a clone draft", async () => {
     const queryClient = createTestQueryClient();
     queryClient.setQueryData(queryKeys.admin.routine("1"), {
@@ -254,6 +274,33 @@ describe("AdminRoutineForm", () => {
 
     expect(screen.getByDisplayValue("Fresh backpack step")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Old cached step")).not.toBeInTheDocument();
+  });
+
+  it("uses cached clone source data when the refresh fails", async () => {
+    const queryClient = createTestQueryClient();
+    let requestCount = 0;
+    queryClient.setQueryData(queryKeys.admin.routine("1"), mockCloneSourceRoutine);
+    server.use(
+      http.get("/api/admin/routines/1", () => {
+        requestCount += 1;
+        return HttpResponse.json(
+          { error: { code: "NETWORK_ERROR", message: "offline" } },
+          { status: 503 },
+        );
+      }),
+    );
+
+    renderCloneForm(queryClient);
+
+    await waitFor(() => {
+      expect(requestCount).toBe(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Leave for School (Copy)");
+    });
+
+    expect(screen.queryByText("Could not load routine.")).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Pack backpack")).toBeInTheDocument();
   });
 
   it("submits a clone as a fresh routine with copied asset ids and no source ids", async () => {
@@ -606,6 +653,31 @@ describe("AdminRoutineForm", () => {
     await user.click(screen.getByRole("button", { name: "Remove item 4" }));
     await user.click(screen.getByRole("button", { name: "Remove item 3" }));
     expect(addButtons()).toHaveLength(1);
+  });
+
+  it("uses cached edit data when a refetch fails", async () => {
+    const queryClient = createTestQueryClient();
+    let requestCount = 0;
+    queryClient.setQueryData(queryKeys.admin.routine("1"), mockExistingRoutine);
+    server.use(
+      http.get("/api/admin/routines/1", () => {
+        requestCount += 1;
+        return HttpResponse.json(
+          { error: { code: "NETWORK_ERROR", message: "offline" } },
+          { status: 503 },
+        );
+      }),
+    );
+
+    renderEditForm(queryClient);
+
+    await waitFor(() => {
+      expect(requestCount).toBe(1);
+    });
+
+    expect(screen.getByRole("heading", { name: "Edit Routine" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toHaveValue("Morning Routine");
+    expect(screen.queryByText("Could not load routine.")).not.toBeInTheDocument();
   });
 
   it("shows error state when loading existing routine fails", async () => {

--- a/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
+++ b/packages/client/tests/features/admin/routines/AdminRoutineForm.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { http, HttpResponse } from "msw";
 import { server } from "../../../msw/server.js";
+import { queryKeys } from "../../../../src/lib/query-keys.js";
 import AdminRoutineForm from "../../../../src/features/admin/routines/AdminRoutineForm.js";
 
 const mockExistingRoutine = {
@@ -72,10 +73,14 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
-function renderCreateForm() {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+}
+
+function renderCreateForm() {
+  const queryClient = createTestQueryClient();
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -88,11 +93,7 @@ function renderCreateForm() {
   );
 }
 
-function renderCloneForm() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
-
+function renderCloneForm(queryClient = createTestQueryClient()) {
   return render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={["/admin/routines/new?cloneFrom=1"]}>
@@ -106,9 +107,7 @@ function renderCloneForm() {
 
 function renderCloneFormWithEditRoute() {
   useRealNavigate = true;
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+  const queryClient = createTestQueryClient();
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -124,9 +123,7 @@ function renderCloneFormWithEditRoute() {
 }
 
 function renderEditForm() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-  });
+  const queryClient = createTestQueryClient();
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -210,6 +207,53 @@ describe("AdminRoutineForm", () => {
       "/assets/backpack.png",
     );
     expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+  });
+
+  it("refreshes stale cached source data before populating a clone draft", async () => {
+    const queryClient = createTestQueryClient();
+    queryClient.setQueryData(queryKeys.admin.routine("1"), {
+      ...mockCloneSourceRoutine,
+      name: "Old School Routine",
+      items: [
+        {
+          id: 20,
+          routineId: 1,
+          label: "Old cached step",
+          sortOrder: 0,
+          imageAssetId: null,
+          imageUrl: null,
+        },
+      ],
+    });
+    server.use(
+      http.get("/api/admin/routines/1", () =>
+        HttpResponse.json({
+          data: {
+            ...mockCloneSourceRoutine,
+            name: "Updated School Routine",
+            items: [
+              {
+                id: 20,
+                routineId: 1,
+                label: "Fresh backpack step",
+                sortOrder: 0,
+                imageAssetId: 8,
+                imageUrl: "/assets/backpack.png",
+              },
+            ],
+          },
+        }),
+      ),
+    );
+
+    renderCloneForm(queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Name")).toHaveValue("Updated School Routine (Copy)");
+    });
+
+    expect(screen.getByDisplayValue("Fresh backpack step")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Old cached step")).not.toBeInTheDocument();
   });
 
   it("submits a clone as a fresh routine with copied asset ids and no source ids", async () => {

--- a/packages/client/tests/features/admin/routines/AdminRoutinesList.test.tsx
+++ b/packages/client/tests/features/admin/routines/AdminRoutinesList.test.tsx
@@ -101,6 +101,29 @@ describe("AdminRoutinesList", () => {
     expect(screen.getByText("Active")).toBeInTheDocument();
   });
 
+  it("shows clone links for each routine row", async () => {
+    server.use(
+      http.get("/api/admin/routines", () =>
+        HttpResponse.json({ data: mockRoutines }),
+      ),
+    );
+
+    renderList();
+
+    await waitFor(() => {
+      expect(screen.getByText("Morning Routine")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("link", { name: "Clone Morning Routine" })).toHaveAttribute(
+      "href",
+      "/admin/routines/new?cloneFrom=1",
+    );
+    expect(screen.getByRole("link", { name: "Clone Bedtime Routine" })).toHaveAttribute(
+      "href",
+      "/admin/routines/new?cloneFrom=2",
+    );
+  });
+
   it("calls archive endpoint when Archive is clicked", async () => {
     let archiveCalled = false;
     server.use(


### PR DESCRIPTION
## Summary

- add a client-only routine clone flow using `/admin/routines/new?cloneFrom=<id>`
- add a Clone action to each admin routine row, including archived routines
- copy active checklist items, routine settings, and asset references into an unsaved draft without source ids
- refresh routine detail data before populating clone drafts and repopulate after primary Create navigates to edit mode
- add unit and Playwright coverage for clone creation, trim/save behavior, source preservation, stale cache, and create-then-save edge cases

Closes #140

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test -- --run --reporter=dot` → 1191 passed
- `npm run test:e2e` → 67 passed
- roborev branch review job 206 → no issues found
- real browser validation in the in-app browser against `http://localhost:5173` on an isolated database:
  - created a source routine through the UI
  - cloned with Save & Close and verified the source remained unchanged
  - cloned with primary Create, performed a second save/reopen, and verified persisted item-backed inputs stayed stable
  - checked browser console errors: none
